### PR TITLE
fix(android): authenticate downloads without HEAD probe

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -736,10 +736,13 @@ class ConsoleUtilitiesApp:
         def extract():
             try:
                 with ZipFile(zip_path, "r") as zip_ref:
-                    total_files = len(zip_ref.namelist())
-                    for i, file_info in enumerate(zip_ref.infolist()):
-                        zip_ref.extract(file_info, output_folder)
-                        progress = int((i + 1) / total_files * 100)
+                    members = zip_ref.infolist()
+                    total_bytes = sum(m.file_size for m in members) or 1
+                    written = 0
+                    for member in members:
+                        zip_ref.extract(member, output_folder)
+                        written += member.file_size
+                        progress = int(written / total_bytes * 100)
                         self.state.loading.progress = progress
                         self.state.loading.message = (
                             f"Extracting {zip_name}... {progress}%"
@@ -770,10 +773,12 @@ class ConsoleUtilitiesApp:
             try:
                 with rarfile.RarFile(rar_path, "r") as rf:
                     members = rf.infolist()
-                    total = len(members)
-                    for i, member in enumerate(members):
+                    total_bytes = sum(getattr(m, "file_size", 0) for m in members) or 1
+                    written = 0
+                    for member in members:
                         rf.extract(member, output_folder)
-                        progress = int((i + 1) / total * 100)
+                        written += getattr(member, "file_size", 0)
+                        progress = int(written / total_bytes * 100)
                         self.state.loading.progress = progress
                         self.state.loading.message = (
                             f"Extracting {rar_name}... {progress}%"
@@ -803,10 +808,12 @@ class ConsoleUtilitiesApp:
             try:
                 with rarfile.RarFile(sz_path, "r") as rf:
                     members = rf.infolist()
-                    total = len(members)
-                    for i, member in enumerate(members):
+                    total_bytes = sum(getattr(m, "file_size", 0) for m in members) or 1
+                    written = 0
+                    for member in members:
                         rf.extract(member, output_folder)
-                        progress = int((i + 1) / total * 100)
+                        written += getattr(member, "file_size", 0)
+                        progress = int(written / total_bytes * 100)
                         self.state.loading.progress = progress
                         self.state.loading.message = (
                             f"Extracting {sz_name}... {progress}%"

--- a/src/app.py
+++ b/src/app.py
@@ -8,7 +8,7 @@ all components: state, settings, services, input, and UI.
 import pygame
 import os
 import sys
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Tuple
 
 from constants import (
     BEZEL_INSET,
@@ -121,30 +121,24 @@ class ConsoleUtilitiesApp:
         pygame.init()
         pygame.display.set_caption("Console Utilities")
 
-        # Create display - auto-detect native resolution on console/Android
+        # Create the physical display surface; rendering targets an off-screen
+        # 800x600 framebuffer (self.screen) that is scale-blitted to the display
+        # via _present() so a user-configurable ui_scale can zoom the UI.
         if DEV_MODE:
-            self.screen = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
+            self.display = pygame.display.set_mode((SCREEN_WIDTH, SCREEN_HEIGHT))
         elif BUILD_TARGET == "android":
             display_info = pygame.display.Info()
-            native_w, native_h = display_info.current_w, display_info.current_h
-            if native_h > native_w:
-                # Portrait: use fixed 800x600 scaled to fit
-                self.screen = pygame.display.set_mode(
-                    (SCREEN_WIDTH, SCREEN_HEIGHT),
-                    pygame.SCALED | pygame.FULLSCREEN,
-                )
-            else:
-                # Landscape: use native resolution
-                self.screen = pygame.display.set_mode(
-                    (native_w, native_h),
-                    pygame.SCALED | pygame.FULLSCREEN,
-                )
+            self.display = pygame.display.set_mode(
+                (display_info.current_w, display_info.current_h),
+                pygame.SCALED | pygame.FULLSCREEN,
+            )
         else:
             display_info = pygame.display.Info()
-            self.screen = pygame.display.set_mode(
+            self.display = pygame.display.set_mode(
                 (display_info.current_w, display_info.current_h),
                 pygame.FULLSCREEN,
             )
+        self.screen = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT)).convert()
         self.clock = pygame.time.Clock()
         font_path = os.path.join(SCRIPT_DIR, "assets", "fonts", "VT323-Regular.ttf")
         if not os.path.exists(font_path):
@@ -186,6 +180,12 @@ class ConsoleUtilitiesApp:
         self.settings = load_settings()
         update_json_file_path(self.settings)
         self.data = load_main_systems_data(self.settings)
+
+        # Compute present-scale geometry now that ui_scale is known
+        self._present_scale: float = 1.0
+        self._present_size: Tuple[int, int] = self.screen.get_size()
+        self._present_offset: Tuple[int, int] = (0, 0)
+        self._update_present_geometry()
 
         # Load controller mapping
         load_controller_mapping()
@@ -362,7 +362,7 @@ class ConsoleUtilitiesApp:
             if self.scanline_surface:
                 self.screen.blit(self.scanline_surface, (0, 0))
             self.screen.blit(self.bezel_surface, (0, 0))
-            pygame.display.flip()
+            self._present()
 
             # Handle events
             for event in pygame.event.get():
@@ -401,7 +401,8 @@ class ConsoleUtilitiesApp:
                             last_input_time = current_time
 
                 elif event.type == pygame.MOUSEBUTTONDOWN:
-                    if touch_detected and skip_btn_rect.collidepoint(event.pos):
+                    pos = self._translate_pos(event.pos)
+                    if touch_detected and skip_btn_rect.collidepoint(pos):
                         mapping = {"touchscreen_mode": True}
                         save_controller_mapping(mapping)
                         return True
@@ -562,18 +563,21 @@ class ConsoleUtilitiesApp:
         """Restore display after returning from an external activity (SAF picker etc)."""
         try:
             self._set_android_immersive_mode()
-            w, h = self.screen.get_size()
-            self.screen = pygame.display.set_mode(
-                (w, h), pygame.SCALED | pygame.FULLSCREEN
+            dw, dh = self.display.get_size()
+            self.display = pygame.display.set_mode(
+                (dw, dh), pygame.SCALED | pygame.FULLSCREEN
             )
+            self._update_present_geometry()
 
-            # Recreate overlay surfaces (GPU textures are lost on context restore)
+            # Recreate overlay surfaces (GPU textures are lost on context restore).
+            # Overlays sit on the 800x600 logical framebuffer and scale with it.
+            lw, lh = self.screen.get_size()
             self.scanline_surface = None
             if self.theme.crt_scanlines:
-                self.scanline_surface = pygame.Surface((w, h), pygame.SRCALPHA)
-                for y in range(0, h, 3):
+                self.scanline_surface = pygame.Surface((lw, lh), pygame.SRCALPHA)
+                for y in range(0, lh, 3):
                     pygame.draw.line(
-                        self.scanline_surface, (0, 0, 0, 40), (0, y), (w, y)
+                        self.scanline_surface, (0, 0, 0, 40), (0, y), (lw, y)
                     )
 
             self.bezel_surface = self._create_crt_bezel()
@@ -591,49 +595,43 @@ class ConsoleUtilitiesApp:
             log_error(f"[restore_display] Error, will retry: {e}")
 
     def _handle_android_orientation(self, new_w: int, new_h: int):
-        """Handle Android orientation change. Portrait keeps 800x600, landscape resizes."""
-        is_portrait = new_h > new_w
-        if is_portrait:
-            # Portrait: use fixed 800x600 with SCALED to fit
-            self.screen = pygame.display.set_mode(
-                (SCREEN_WIDTH, SCREEN_HEIGHT),
-                pygame.SCALED | pygame.FULLSCREEN,
-            )
-        else:
-            # Landscape: use native resolution
-            self.screen = pygame.display.set_mode(
-                (new_w, new_h), pygame.SCALED | pygame.FULLSCREEN
-            )
+        """Handle Android orientation change. Display tracks native size; framebuffer stays 800x600."""
+        self.display = pygame.display.set_mode(
+            (new_w, new_h), pygame.SCALED | pygame.FULLSCREEN
+        )
+        self._update_present_geometry()
 
-        # Recreate theme and overlays
+        # Recreate theme and overlays at logical framebuffer size
         self.theme = Theme()
+        lw, lh = self.screen.get_size()
         self.scanline_surface = None
         if self.theme.crt_scanlines:
-            sw, sh = self.screen.get_size()
-            self.scanline_surface = pygame.Surface((sw, sh), pygame.SRCALPHA)
-            for y in range(0, sh, 3):
-                pygame.draw.line(self.scanline_surface, (0, 0, 0, 40), (0, y), (sw, y))
+            self.scanline_surface = pygame.Surface((lw, lh), pygame.SRCALPHA)
+            for y in range(0, lh, 3):
+                pygame.draw.line(self.scanline_surface, (0, 0, 0, 40), (0, y), (lw, y))
         self.bezel_surface = self._create_crt_bezel()
         self.vignette_surface = self._create_vignette()
         self.image_cache.clear()
 
     def _handle_resize(self, new_w: int, new_h: int):
-        """Handle screen resize (Android orientation change)."""
-        self.screen = pygame.display.set_mode((new_w, new_h), pygame.RESIZABLE)
+        """Handle screen resize (desktop window resize)."""
+        self.display = pygame.display.set_mode((new_w, new_h), pygame.RESIZABLE)
+        self._update_present_geometry()
 
         # Recreate theme
         self.theme = Theme()
 
-        # Recreate scanline overlay
+        # Recreate overlays at logical framebuffer size
+        lw, lh = self.screen.get_size()
         self.scanline_surface = None
         if self.theme.crt_scanlines:
-            self.scanline_surface = pygame.Surface((new_w, new_h), pygame.SRCALPHA)
-            for y in range(0, new_h, 3):
+            self.scanline_surface = pygame.Surface((lw, lh), pygame.SRCALPHA)
+            for y in range(0, lh, 3):
                 pygame.draw.line(
                     self.scanline_surface,
                     (0, 0, 0, 40),
                     (0, y),
-                    (new_w, y),
+                    (lw, y),
                 )
 
         # Recreate bezel overlay
@@ -645,6 +643,43 @@ class ConsoleUtilitiesApp:
         # Recreate font for controller mapping screen
         font_path = self.theme.font_path
         self.font = pygame.font.Font(font_path, self.theme.font_size_md)
+
+    def _update_present_geometry(self):
+        """Recompute scale, target size, and offset used by _present()."""
+        dw, dh = self.display.get_size()
+        lw, lh = self.screen.get_size()
+        natural_scale = min(dw / lw, dh / lh)
+        try:
+            user_scale = float(self.settings.get("ui_scale", 1.0) or 1.0)
+        except (TypeError, ValueError):
+            user_scale = 1.0
+        user_scale = max(0.5, min(10.0, user_scale))
+        self._present_scale = natural_scale * user_scale
+        target_w = max(1, int(lw * self._present_scale))
+        target_h = max(1, int(lh * self._present_scale))
+        self._present_size = (target_w, target_h)
+        self._present_offset = ((dw - target_w) // 2, (dh - target_h) // 2)
+
+    def _present(self):
+        """Scale-blit the logical framebuffer to the display and flip."""
+        if self._present_size == self.screen.get_size() and self._present_offset == (
+            0,
+            0,
+        ):
+            self.display.blit(self.screen, (0, 0))
+        else:
+            scaled = pygame.transform.scale(self.screen, self._present_size)
+            self.display.fill((0, 0, 0))
+            self.display.blit(scaled, self._present_offset)
+        pygame.display.flip()
+
+    def _translate_pos(self, pos: Tuple[int, int]) -> Tuple[int, int]:
+        """Translate physical display coordinates to logical framebuffer coordinates."""
+        if self._present_scale <= 0:
+            return pos
+        x = (pos[0] - self._present_offset[0]) / self._present_scale
+        y = (pos[1] - self._present_offset[1]) / self._present_scale
+        return (int(x), int(y))
 
     def _get_thumbnail(
         self, game: Any, system_data: Optional[dict] = None
@@ -805,7 +840,7 @@ class ConsoleUtilitiesApp:
         if self.scanline_surface:
             self.screen.blit(self.scanline_surface, (0, 0))
         self.screen.blit(self.bezel_surface, (0, 0))
-        pygame.display.flip()
+        self._present()
         # Process events to prevent freezing
         pygame.event.pump()
 
@@ -916,17 +951,20 @@ class ConsoleUtilitiesApp:
 
                 elif event.type == pygame.MOUSEBUTTONDOWN:
                     if event.button == 1:
+                        event.pos = self._translate_pos(event.pos)
                         self.state.input_mode = "touch"
                         self.touch.handle_mouse_down(event)
 
                 elif event.type == pygame.MOUSEBUTTONUP:
                     if event.button == 1:
+                        event.pos = self._translate_pos(event.pos)
                         self.touch.handle_mouse_up(event, on_click=self._handle_click)
 
                 elif event.type == pygame.MOUSEWHEEL:
                     self.touch.handle_mouse_wheel(event, on_scroll=self._handle_scroll)
 
                 elif event.type == pygame.MOUSEMOTION:
+                    event.pos = self._translate_pos(event.pos)
                     self.touch.handle_mouse_motion(event, on_scroll=self._handle_scroll)
 
                 elif event.type == pygame.VIDEORESIZE:
@@ -938,7 +976,7 @@ class ConsoleUtilitiesApp:
                             self._restore_android_display()
                         else:
                             # Only handle actual orientation changes, not keyboard/navbar resize
-                            cur_w, cur_h = self.screen.get_size()
+                            cur_w, cur_h = self.display.get_size()
                             was_portrait = cur_h > cur_w
                             is_portrait = event.h > event.w
                             if was_portrait != is_portrait:
@@ -1073,7 +1111,7 @@ class ConsoleUtilitiesApp:
                     if self.scanline_surface:
                         self.screen.blit(self.scanline_surface, (0, 0))
                     self.screen.blit(self.bezel_surface, (0, 0))
-                    pygame.display.flip()
+                    self._present()
 
                     # Web companion: capture frame for MJPEG thumbnail
                     if self.web_companion and self.web_companion._running:
@@ -4035,6 +4073,18 @@ class ConsoleUtilitiesApp:
             save_settings(self.settings)
             # Re-initialize download manager with the new setting
             self._init_download_manager()
+        elif action == "cycle_ui_scale":
+            presets = [0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 3.0, 5.0, 10.0]
+            try:
+                current = float(self.settings.get("ui_scale", 1.0) or 1.0)
+            except (TypeError, ValueError):
+                current = 1.0
+            idx = min(
+                range(len(presets)), key=lambda i: abs(presets[i] - current)
+            )
+            self.settings["ui_scale"] = presets[(idx + 1) % len(presets)]
+            save_settings(self.settings)
+            self._update_present_geometry()
         elif action == "redraw_ui":
             self._restore_android_display()
         elif action == "request_storage_permission":

--- a/src/app.py
+++ b/src/app.py
@@ -4524,6 +4524,10 @@ class ConsoleUtilitiesApp:
                 f.write(app_id)
             self.state.steam_shortcut.output_folder = folder_path
             self.state.steam_shortcut.step = "complete"
+            # Remember this folder so the picker opens here next time
+            if self.settings.get("steam_shortcut_folder") != folder_path:
+                self.settings["steam_shortcut_folder"] = folder_path
+                save_settings(self.settings)
         except Exception as e:
             self.state.steam_shortcut.show = False
             self.state.folder_browser.show = False
@@ -4689,7 +4693,13 @@ class ConsoleUtilitiesApp:
                     elif os.path.isdir(os.path.dirname(custom)):
                         path = os.path.dirname(custom)
         elif selection_type == "steam_shortcut":
-            path = self.settings.get("roms_dir", SCRIPT_DIR)
+            saved = self.settings.get("steam_shortcut_folder", "")
+            if saved and os.path.isdir(saved):
+                path = saved
+            elif saved and os.path.isdir(os.path.dirname(saved)):
+                path = os.path.dirname(saved)
+            else:
+                path = self.settings.get("roms_dir", SCRIPT_DIR)
         elif selection_type == "mvp_psp_patcher_rom":
             path = self.settings.get("roms_dir", SCRIPT_DIR)
         elif selection_type == "syncthing_base_path":
@@ -5679,6 +5689,8 @@ class ConsoleUtilitiesApp:
 
     def _navigate_folder_browser(self, direction: str):
         """Navigate folder browser modal with list and button support."""
+        from ui.screens.modals.folder_browser_modal import is_folder_selection_type
+
         fb = self.state.folder_browser
         max_items = len(fb.items) or 1
         selection_type = (
@@ -5686,22 +5698,7 @@ class ConsoleUtilitiesApp:
             if fb.selected_system_to_add
             else "folder"
         )
-        is_folder_selection = selection_type in (
-            "work_dir",
-            "roms_dir",
-            "custom_folder",
-            "esde_media_path",
-            "esde_gamelists_path",
-            "retroarch_thumbnails",
-            "add_system_folder",
-            "ia_collection_folder",
-            "dedupe_folder",
-            "rename_folder",
-            "ghost_cleaner_folder",
-            "ia_download_folder",
-            "scraper_batch_folder",
-            "folder",
-        )
+        is_folder_selection = is_folder_selection_type(selection_type)
 
         if fb.focus_area == "list":
             if direction == "up":

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -73,6 +73,8 @@ class Settings:
     esde_media_path: str = ""
     esde_gamelists_path: str = ""
     retroarch_thumbnails_path: str = ""
+    # Steam shortcut utility
+    steam_shortcut_folder: str = ""
 
     def __post_init__(self):
         """Set default paths if not specified."""

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -57,6 +57,7 @@ class Settings:
     use_python_downloader: bool = (
         False  # Use Python downloads/zip instead of Android-native
     )
+    ui_scale: float = 1.0  # Multiplier on top of natural fit (0.5x .. 10x)
     # Web Companion
     web_companion_enabled: bool = True
     # Syncthing Save Sync

--- a/src/droid/download_manager.py
+++ b/src/droid/download_manager.py
@@ -356,6 +356,11 @@ class AndroidDownloadManager:
                 elif new_status in ("extracting", "moving"):
                     item.status = new_status
                     item.progress = progress
+                    # Pass through byte counters and speed so the downloads
+                    # screen can render ETA during extraction.
+                    item.downloaded = status_data.get("downloaded", item.downloaded)
+                    item.total_size = status_data.get("total_size", item.total_size)
+                    item.speed = status_data.get("speed", 0.0)
                 elif new_status == "completed":
                     item.status = "completed"
                     item.progress = 1.0

--- a/src/droid/download_service.py
+++ b/src/droid/download_service.py
@@ -132,40 +132,53 @@ def _process_download(service, task):
     request_headers = _build_download_headers(url)
     request_headers.update(auth_headers)
 
-    # Resolve final URL (follow redirects preserving auth).
-    # requests strips Authorization/Cookie on cross-host redirects,
-    # so for ALL authenticated downloads we resolve manually first.
+    # requests strips Authorization/Cookie on cross-host redirects, and some
+    # auth-protected servers reject HEAD requests outright (401). Use a single
+    # streaming GET — manually following redirects when auth is present — to
+    # both resolve the URL and read content-length/accept-ranges. Matches the
+    # desktop DownloadManager flow.
     has_auth = bool(auth_headers) or bool(cookies)
 
     try:
         resolved_url = url
-        if has_auth:
-            resolved_url = _resolve_redirects(url, request_headers, cookies)
-            if resolved_url is None:
-                write_status(
-                    work_dir,
-                    item_id,
-                    {
-                        "status": "failed",
-                        "progress": 0.0,
-                        "error": "Auth redirect resolution failed",
-                    },
-                )
-                return
+        response = None
 
-        # Probe for range support and content length
-        resp = requests.head(
-            resolved_url,
-            headers=request_headers,
-            cookies=cookies,
-            timeout=(15, 30),
-            allow_redirects=True,
-        )
-        resp.raise_for_status()
-        total_size = int(resp.headers.get("content-length", 0))
-        accept_ranges = resp.headers.get("accept-ranges", "").lower()
-        # Use the final redirected URL for actual downloads
-        resolved_url = resp.url
+        if has_auth:
+            current_url = url
+            for _ in range(5):
+                resp = requests.get(
+                    current_url,
+                    stream=True,
+                    timeout=(15, 30),
+                    headers=request_headers,
+                    cookies=cookies,
+                    allow_redirects=False,
+                )
+                if resp.status_code in (301, 302, 303, 307, 308):
+                    current_url = resp.headers.get("Location", current_url)
+                    resp.close()
+                    continue
+                resp.raise_for_status()
+                response = resp
+                resolved_url = current_url
+                break
+            else:
+                raise requests.exceptions.TooManyRedirects("Too many redirects")
+        else:
+            response = requests.get(
+                url,
+                stream=True,
+                timeout=(15, 30),
+                headers=request_headers,
+                cookies=cookies,
+                allow_redirects=True,
+            )
+            response.raise_for_status()
+            resolved_url = response.url
+
+        total_size = int(response.headers.get("content-length", 0))
+        accept_ranges = response.headers.get("accept-ranges", "").lower()
+        response.close()
 
         write_status(
             work_dir,
@@ -552,46 +565,6 @@ def _start_extraction_service(service, task, file_path):
                 "progress": 1.0,
             },
         )
-
-
-def _resolve_redirects(url, headers, cookies, max_redirects=5):
-    """
-    Follow redirects manually, preserving auth headers.
-    Returns final URL or None.
-    """
-    import requests
-
-    current_url = url
-    verify = True
-    for _ in range(max_redirects):
-        try:
-            resp = requests.get(
-                current_url,
-                stream=True,
-                timeout=30,
-                headers=headers,
-                cookies=cookies,
-                allow_redirects=False,
-                verify=verify,
-            )
-            if resp.status_code in (301, 302, 303, 307, 308):
-                current_url = resp.headers.get("Location", current_url)
-                resp.close()
-                continue
-            else:
-                resp.close()
-                return current_url
-        except (
-            requests.exceptions.SSLError,
-            requests.exceptions.ConnectionError,
-        ):
-            if verify:
-                verify = False
-                continue
-            return None
-        except Exception:
-            return None
-    return None
 
 
 def _build_download_headers(url):

--- a/src/droid/service.py
+++ b/src/droid/service.py
@@ -184,24 +184,51 @@ def _process_file(
 def _extract_zip(
     service, item_id, file_path, filename, work_dir, roms_folder, system_data, formats
 ):
-    """Extract a ZIP file with progress reporting."""
+    """Extract a ZIP file with byte-weighted progress and speed/ETA reporting."""
+    from utils.progress import SpeedTracker
+
     update_notification(service, f"Extracting: {filename}", 0, 100)
-    write_status(work_dir, item_id, {"status": "extracting", "progress": 0.0})
 
     extract_contents = system_data.get("extract_contents", True)
 
     with ZipFile(file_path, "r") as zip_ref:
-        total_files = len(zip_ref.namelist())
-        for i, file_info in enumerate(zip_ref.infolist()):
+        members = zip_ref.infolist()
+        total_bytes = sum(m.file_size for m in members) or 1
+        tracker = SpeedTracker()
+        written = 0
+        notif_step = max(total_bytes // 20, 1)
+        next_notif = notif_step
+        write_status(
+            work_dir,
+            item_id,
+            {
+                "status": "extracting",
+                "progress": 0.0,
+                "downloaded": 0,
+                "total_size": total_bytes,
+                "speed": 0.0,
+            },
+        )
+        for member in members:
             if _check_cancel(work_dir, item_id):
                 return
-            zip_ref.extract(file_info, work_dir)
-            progress = (i + 1) / total_files
+            zip_ref.extract(member, work_dir)
+            written += member.file_size
+            speed = tracker.update(written)
+            progress = written / total_bytes
             write_status(
-                work_dir, item_id, {"status": "extracting", "progress": progress}
+                work_dir,
+                item_id,
+                {
+                    "status": "extracting",
+                    "progress": progress,
+                    "downloaded": written,
+                    "total_size": total_bytes,
+                    "speed": speed,
+                },
             )
-            # Update notification every ~10% to avoid excessive updates
-            if i % max(total_files // 10, 1) == 0:
+            if written >= next_notif or written == total_bytes:
+                next_notif += notif_step
                 update_notification(
                     service, f"Extracting: {filename}", int(progress * 100), 100
                 )
@@ -264,18 +291,45 @@ def _extract_zip(
 
 
 def _decompress_nsz(service, item_id, file_path, work_dir, roms_folder, system_data):
-    """Decompress an NSZ file with progress reporting."""
+    """Decompress an NSZ file with real-time progress, speed, and ETA."""
+    from utils.nsz import decompress_nsz_file
+    from utils.progress import SpeedTracker
+
     filename = os.path.basename(file_path)
     update_notification(service, f"Decompressing: {filename}", 0, 100)
-    write_status(work_dir, item_id, {"status": "extracting", "progress": 0.0})
+    write_status(
+        work_dir,
+        item_id,
+        {
+            "status": "extracting",
+            "progress": 0.0,
+            "downloaded": 0,
+            "total_size": 0,
+            "speed": 0.0,
+        },
+    )
 
-    from utils.nsz import decompress_nsz_file
+    tracker = SpeedTracker()
+    last_notif_pct = [-1]
 
-    def nsz_progress(text, percent):
+    def nsz_progress(step, processed, total):
+        speed = tracker.update(processed)
+        progress = (processed / total) if total > 0 else 0.0
         write_status(
-            work_dir, item_id, {"status": "extracting", "progress": percent / 100.0}
+            work_dir,
+            item_id,
+            {
+                "status": "extracting",
+                "progress": progress,
+                "downloaded": processed,
+                "total_size": total,
+                "speed": speed,
+            },
         )
-        update_notification(service, f"Decompressing: {filename}", percent, 100)
+        pct = int(progress * 100)
+        if pct != last_notif_pct[0]:
+            last_notif_pct[0] = pct
+            update_notification(service, f"Decompressing: {filename}", pct, 100)
 
     keys_path = system_data.get("nsz_keys_path", "")
     success = decompress_nsz_file(file_path, work_dir, keys_path, nsz_progress)

--- a/src/droid/service.py
+++ b/src/droid/service.py
@@ -184,54 +184,70 @@ def _process_file(
 def _extract_zip(
     service, item_id, file_path, filename, work_dir, roms_folder, system_data, formats
 ):
-    """Extract a ZIP file with byte-weighted progress and speed/ETA reporting."""
+    """Extract a ZIP in parallel with byte-weighted progress and speed/ETA."""
+    import threading
     from utils.progress import SpeedTracker
+    from utils.parallel_extract import parallel_extract_zip
 
     update_notification(service, f"Extracting: {filename}", 0, 100)
 
     extract_contents = system_data.get("extract_contents", True)
 
-    with ZipFile(file_path, "r") as zip_ref:
-        members = zip_ref.infolist()
-        total_bytes = sum(m.file_size for m in members) or 1
-        tracker = SpeedTracker()
-        written = 0
-        notif_step = max(total_bytes // 20, 1)
-        next_notif = notif_step
+    tracker = SpeedTracker()
+    cancel_event = threading.Event()
+    state_lock = threading.Lock()
+    last_notif_pct = [-1]
+
+    def cancel_check():
+        if cancel_event.is_set():
+            return True
+        if _check_cancel(work_dir, item_id):
+            cancel_event.set()
+            return True
+        return False
+
+    def on_progress(written, total):
+        with state_lock:
+            speed = tracker.update(written)
+        progress = (written / total) if total else 0.0
         write_status(
             work_dir,
             item_id,
             {
                 "status": "extracting",
-                "progress": 0.0,
-                "downloaded": 0,
-                "total_size": total_bytes,
-                "speed": 0.0,
+                "progress": progress,
+                "downloaded": written,
+                "total_size": total,
+                "speed": speed,
             },
         )
-        for member in members:
-            if _check_cancel(work_dir, item_id):
-                return
-            zip_ref.extract(member, work_dir)
-            written += member.file_size
-            speed = tracker.update(written)
-            progress = written / total_bytes
+        pct = int(progress * 100)
+        if pct != last_notif_pct[0]:
+            last_notif_pct[0] = pct
+            update_notification(
+                service, f"Extracting: {filename}", pct, 100
+            )
+
+    ok = parallel_extract_zip(
+        file_path,
+        work_dir,
+        on_progress=on_progress,
+        should_cancel=cancel_check,
+    )
+    if not ok:
+        if not cancel_event.is_set():
+            # Distinguish extraction error from user cancellation
             write_status(
                 work_dir,
                 item_id,
                 {
-                    "status": "extracting",
-                    "progress": progress,
-                    "downloaded": written,
-                    "total_size": total_bytes,
-                    "speed": speed,
+                    "status": "failed",
+                    "progress": 0.0,
+                    "error": "ZIP extraction failed",
                 },
             )
-            if written >= next_notif or written == total_bytes:
-                next_notif += notif_step
-                update_notification(
-                    service, f"Extracting: {filename}", int(progress * 100), 100
-                )
+        # If cancelled, _check_cancel already wrote the "cancelled" status.
+        return
 
     os.remove(file_path)
 

--- a/src/nsz/BlockDecompressorReader.py
+++ b/src/nsz/BlockDecompressorReader.py
@@ -20,6 +20,9 @@ class BlockDecompressorReader:
 			self.CompressedBlockOffsetList.append(self.CompressedBlockOffsetList[-1] + compressedBlockSize)
 
 		self.CompressedBlockSizeList = BlockHeader.compressedBlockSizeList
+		# Reuse a single decompressor instance instead of allocating one per
+		# block — fewer object allocations during 5 GB+ extractions.
+		self.__decompressor = ZstdDecompressor()
 
 	def __decompressBlock(self, blockID):
 		if self.CurrentBlockId == blockID:
@@ -31,7 +34,7 @@ class BlockDecompressorReader:
 			decompressedBlockSize = self.BlockHeader.decompressedSize % self.BlockSize
 		self.nspf.seek(self.CompressedBlockOffsetList[blockID])
 		if self.CompressedBlockSizeList[blockID] < decompressedBlockSize:
-			self.CurrentBlock = ZstdDecompressor().decompress(self.nspf.read(self.CompressedBlockSizeList[blockID]))
+			self.CurrentBlock = self.__decompressor.decompress(self.nspf.read(self.CompressedBlockSizeList[blockID]))
 		else:
 			self.CurrentBlock = self.nspf.read(decompressedBlockSize)
 		self.CurrentBlockId = blockID

--- a/src/nsz/NszDecompressor.py
+++ b/src/nsz/NszDecompressor.py
@@ -188,10 +188,14 @@ def __decompressNcz(nspf, f, statusReportInfo, pleaseNoPrint):
 			uncompressedSize = UNCOMPRESSABLE_HEADER_SIZE-sections[0].offset
 			if uncompressedSize > 0:
 				i += uncompressedSize
+		# Larger chunks reduce per-iteration Python overhead, AES cipher
+		# recreations from crypto.seek(), and (importantly) the number of
+		# status callbacks fired. Original library used 0x10000 (64 KB).
+		CHUNK_SZ = 0x100000  # 1 MB
 		while i < end:
 			if useCrypto:
 				crypto.seek(i)
-			chunkSz = 0x10000 if end - i > 0x10000 else end - i
+			chunkSz = CHUNK_SZ if end - i > CHUNK_SZ else end - i
 			if useBlockCompression:
 				inputChunk = blockDecompressorReader.read(chunkSz)
 			else:

--- a/src/services/download_manager.py
+++ b/src/services/download_manager.py
@@ -19,6 +19,7 @@ from state import DownloadQueueItem, DownloadQueueState
 from utils.logging import log_error
 from utils.nsz import decompress_nsz_file
 from utils.progress import SpeedTracker
+from utils.parallel_extract import parallel_extract_zip
 from constants import SCRIPT_DIR
 
 # Minimum file size for parallel downloads (50 MB)
@@ -664,23 +665,26 @@ class DownloadManager:
                 # extra move step (major speedup on slow storage)
                 extract_dir = roms_folder if extract_contents else self.work_dir
 
-                with ZipFile(file_path, "r") as zip_ref:
-                    members = zip_ref.infolist()
-                    total_bytes = sum(m.file_size for m in members) or 1
-                    item.downloaded = 0
-                    item.total_size = total_bytes
-                    item.progress = 0.0
-                    item.speed = 0.0
-                    tracker = SpeedTracker()
-                    written = 0
-                    for member in members:
-                        if self._cancel_current:
-                            return False
-                        zip_ref.extract(member, extract_dir)
-                        written += member.file_size
-                        item.downloaded = written
-                        item.progress = written / total_bytes
-                        item.speed = tracker.update(written)
+                item.downloaded = 0
+                item.total_size = 0
+                item.progress = 0.0
+                item.speed = 0.0
+                tracker = SpeedTracker()
+
+                def on_zip_progress(written: int, total: int):
+                    item.downloaded = written
+                    item.total_size = total
+                    item.progress = min(1.0, written / total) if total else 0.0
+                    item.speed = tracker.update(written)
+
+                ok = parallel_extract_zip(
+                    file_path,
+                    extract_dir,
+                    on_progress=on_zip_progress,
+                    should_cancel=lambda: self._cancel_current,
+                )
+                if not ok:
+                    return False
 
                 os.remove(file_path)
 

--- a/src/services/download_manager.py
+++ b/src/services/download_manager.py
@@ -18,6 +18,7 @@ import requests
 from state import DownloadQueueItem, DownloadQueueState
 from utils.logging import log_error
 from utils.nsz import decompress_nsz_file
+from utils.progress import SpeedTracker
 from constants import SCRIPT_DIR
 
 # Minimum file size for parallel downloads (50 MB)
@@ -665,15 +666,21 @@ class DownloadManager:
 
                 with ZipFile(file_path, "r") as zip_ref:
                     members = zip_ref.infolist()
-                    total = len(members)
-                    # Update progress every ~5% to keep overhead low
-                    update_interval = max(1, total // 20)
-                    for i, member in enumerate(members):
+                    total_bytes = sum(m.file_size for m in members) or 1
+                    item.downloaded = 0
+                    item.total_size = total_bytes
+                    item.progress = 0.0
+                    item.speed = 0.0
+                    tracker = SpeedTracker()
+                    written = 0
+                    for member in members:
                         if self._cancel_current:
                             return False
                         zip_ref.extract(member, extract_dir)
-                        if (i + 1) % update_interval == 0 or i == total - 1:
-                            item.progress = (i + 1) / total
+                        written += member.file_size
+                        item.downloaded = written
+                        item.progress = written / total_bytes
+                        item.speed = tracker.update(written)
 
                 os.remove(file_path)
 
@@ -719,9 +726,18 @@ class DownloadManager:
             # Handle NSZ decompression
             elif filename.endswith(".nsz"):
                 item.status = "extracting"
+                item.downloaded = 0
+                item.total_size = 0
+                item.progress = 0.0
+                item.speed = 0.0
+                tracker = SpeedTracker()
 
-                def nsz_progress(text: str, percent: int):
-                    item.progress = percent / 100.0
+                def nsz_progress(step: str, processed: int, total: int):
+                    item.downloaded = processed
+                    item.total_size = total
+                    if total > 0:
+                        item.progress = min(1.0, processed / total)
+                    item.speed = tracker.update(processed)
 
                 keys_path = self.settings.get("nsz_keys_path", "")
                 success = decompress_nsz_file(

--- a/src/ui/screens/downloads_screen.py
+++ b/src/ui/screens/downloads_screen.py
@@ -316,10 +316,22 @@ class DownloadsScreen:
                 item.progress,
                 fill_color=self.theme.warning,
             )
-            # Label below the progress bar
+            # Below the bar: label, optionally augmented with speed + ETA if
+            # the extraction phase is reporting byte progress.
+            if item.speed > 0 and item.total_size > 0:
+                speed_text = self._format_speed(item.speed)
+                eta_text = self._format_eta(
+                    item.total_size, item.downloaded, item.speed
+                )
+                if eta_text:
+                    sub_text = f"{label} {speed_text} - {eta_text}"
+                else:
+                    sub_text = f"{label} {speed_text}"
+            else:
+                sub_text = label
             self.text.render(
                 screen,
-                label,
+                sub_text,
                 (rect.centerx, rect.centery + 8),
                 color=(
                     self.theme.background

--- a/src/ui/screens/modals/folder_browser_modal.py
+++ b/src/ui/screens/modals/folder_browser_modal.py
@@ -12,6 +12,38 @@ from ui.molecules.action_button import ActionButton
 from ui.atoms.text import Text
 
 
+_FOLDER_SELECTION_TYPES = frozenset(
+    {
+        "work_dir",
+        "roms_dir",
+        "custom_folder",
+        "esde_media_path",
+        "esde_gamelists_path",
+        "retroarch_thumbnails",
+        "add_system_folder",
+        "ia_collection_folder",
+        "dedupe_folder",
+        "rename_folder",
+        "ghost_cleaner_folder",
+        "ia_download_folder",
+        "steam_shortcut",
+        "scraper_batch_folder",
+        "syncthing_base_path",
+        "custom_save_source",
+        "folder",
+    }
+)
+
+_FOLDER_SELECTION_PREFIXES = ("syncthing_override_", "custom_save_map_")
+
+
+def is_folder_selection_type(selection_type: str) -> bool:
+    """True when the folder browser modal should expose Select/Cancel buttons."""
+    return selection_type in _FOLDER_SELECTION_TYPES or selection_type.startswith(
+        _FOLDER_SELECTION_PREFIXES
+    )
+
+
 class FolderBrowserModal:
     """
     Folder browser modal.
@@ -83,26 +115,7 @@ class FolderBrowserModal:
             max_width=content_rect.width,
         )
 
-        # Determine if this is a folder selection (show buttons) or file selection (no buttons)
-        is_folder_selection = selection_type in (
-            "work_dir",
-            "roms_dir",
-            "custom_folder",
-            "esde_media_path",
-            "esde_gamelists_path",
-            "retroarch_thumbnails",
-            "add_system_folder",
-            "ia_collection_folder",
-            "dedupe_folder",
-            "rename_folder",
-            "ghost_cleaner_folder",
-            "ia_download_folder",
-            "steam_shortcut",
-            "scraper_batch_folder",
-            "syncthing_base_path",
-            "custom_save_source",
-            "folder",
-        ) or selection_type.startswith(("syncthing_override_", "custom_save_map_"))
+        is_folder_selection = is_folder_selection_type(selection_type)
 
         # List area (below path, above buttons if shown)
         button_height = 44

--- a/src/ui/screens/settings_screen.py
+++ b/src/ui/screens/settings_screen.py
@@ -97,6 +97,7 @@ class SettingsScreen:
     ANDROID_SECTION = [
         "--- ANDROID ---",
         "Use Python Downloader",
+        "UI Scale",
         "Redraw UI",
         "Storage Permission",
     ]
@@ -332,6 +333,12 @@ class SettingsScreen:
             elif item == "Use Python Downloader":
                 value = "ON" if settings.get("use_python_downloader", False) else "OFF"
                 items.append((item, value))
+            elif item == "UI Scale":
+                try:
+                    scale = float(settings.get("ui_scale", 1.0) or 1.0)
+                except (TypeError, ValueError):
+                    scale = 1.0
+                items.append((item, f"{scale:g}x"))
             elif item == "Redraw UI":
                 items.append((item, "Refresh"))
             elif item == "Storage Permission":
@@ -424,6 +431,7 @@ class SettingsScreen:
                 "Web Companion": "toggle_web_companion",
                 "Enable Syncthing Helper": "toggle_syncthing_enabled",
                 "Use Python Downloader": "toggle_python_downloader",
+                "UI Scale": "cycle_ui_scale",
                 "Redraw UI": "redraw_ui",
                 "Storage Permission": "request_storage_permission",
                 "Check for Updates": "check_for_updates",

--- a/src/utils/nsz.py
+++ b/src/utils/nsz.py
@@ -28,11 +28,43 @@ def is_nsz_available() -> bool:
     return NSZ_AVAILABLE
 
 
+class _ProgressReport:
+    """List-like proxy for nsz's statusReport that fires a callback on updates.
+
+    The nsz library writes ``statusReport[id] = [processed, verified, total, step]``
+    after every decompressed chunk. We intercept those writes and translate
+    them into ``progress_callback(step, processed, total)`` calls so the UI can
+    show real-time progress, speed, and ETA instead of a hard-coded 30 → 80
+    waypoint.
+    """
+
+    def __init__(self, callback, slot_id=0):
+        self._slots = {}
+        self._callback = callback
+        self._slot_id = slot_id
+
+    def __setitem__(self, key, value):
+        self._slots[key] = value
+        if key != self._slot_id or self._callback is None:
+            return
+        try:
+            processed, _verified, total, step = value
+        except (ValueError, TypeError):
+            return
+        try:
+            self._callback(str(step), int(processed), int(total))
+        except Exception:
+            pass
+
+    def __getitem__(self, key):
+        return self._slots[key]
+
+
 def decompress_nsz_file(
     nsz_file_path: str,
     output_dir: str,
     keys_path: str,
-    progress_callback: Optional[Callable[[str, int], None]] = None,
+    progress_callback: Optional[Callable[[str, int, int], None]] = None,
 ) -> bool:
     """
     Unified NSZ decompression method.
@@ -41,7 +73,8 @@ def decompress_nsz_file(
         nsz_file_path: Path to the NSZ file to decompress
         output_dir: Directory to extract NSP file(s) to
         keys_path: Path to Nintendo Switch keys file
-        progress_callback: Optional callback for progress updates (message, progress_percent)
+        progress_callback: Optional callback ``(step, bytes_processed, bytes_total)``
+            invoked continuously during decompression.
 
     Returns:
         True if decompression was successful, False otherwise
@@ -49,14 +82,6 @@ def decompress_nsz_file(
     filename = os.path.basename(nsz_file_path)
 
     log_error(f"NSZ Called for {filename}")
-    log_error("NSZ Starting Checks:")
-
-    def update_progress(message: str, progress: int):
-        if progress_callback:
-            progress_callback(message, progress)
-        else:
-            print(message)
-
     log_error(f"NSZ Key Path: {keys_path}")
 
     # Check if NSZ library is available
@@ -76,8 +101,6 @@ def decompress_nsz_file(
 
     if keys_path and local_nsz_decompress:
         try:
-            update_progress(f"Decompressing {filename} using NSZ library...", 30)
-
             # Check if NSZ file is valid before attempting decompression
             if not os.path.exists(nsz_file_path):
                 raise FileNotFoundError(f"NSZ file not found: {nsz_file_path}")
@@ -86,12 +109,19 @@ def decompress_nsz_file(
             if file_size == 0:
                 raise ValueError(f"NSZ file is empty: {nsz_file_path}")
 
+            if progress_callback:
+                progress_callback("Decompressing", 0, file_size)
+
             log_error(f"Attempting NSZ decompression of {filename} ({file_size} bytes)")
+            report = _ProgressReport(progress_callback)
             local_nsz_decompress(
-                Path(nsz_file_path), Path(output_dir), True, None, keys_path=keys_path
+                Path(nsz_file_path),
+                Path(output_dir),
+                True,
+                (report, 0),
+                keys_path=keys_path,
             )
             nsz_success = True
-            update_progress("NSZ library decompression successful", 80)
             log_error("NSZ decompression successful using nsz library")
 
         except Exception as e:
@@ -107,9 +137,15 @@ def decompress_nsz_file(
                 log_error("NSZ file appears to be corrupted or incomplete")
 
     if nsz_success:
-        update_progress(f"Decompressing {filename}... Complete", 100)
+        if progress_callback:
+            try:
+                final_size = os.path.getsize(nsz_file_path)
+            except OSError:
+                final_size = 1
+            progress_callback("Decompressing", final_size, final_size)
         return True
     else:
         log_error(f"NSZ decompression failed for {filename}: All methods failed")
-        update_progress(f"NSZ decompression failed for {filename}", 0)
+        if progress_callback:
+            progress_callback("Failed", 0, 1)
         return False

--- a/src/utils/nsz.py
+++ b/src/utils/nsz.py
@@ -5,10 +5,19 @@ Handles decompression of NSZ files to NSP format.
 
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Callable, Optional
 
 from .logging import log_error
+
+
+# Throttle interval for progress callbacks during decompression. The NSZ
+# library reports progress every 64 KB chunk; for a 5 GB file that's ~80k
+# callback invocations. On Android each one writes a JSON IPC file, which
+# easily doubles wall-clock extraction time. Firing at most ~5x/sec keeps
+# the UI responsive without bottlenecking the decompression loop.
+_PROGRESS_THROTTLE_SECONDS = 0.2
 
 # Try to import NSZ module
 try:
@@ -42,6 +51,9 @@ class _ProgressReport:
         self._slots = {}
         self._callback = callback
         self._slot_id = slot_id
+        self._last_emit = 0.0
+        self._last_processed = -1
+        self._last_total = -1
 
     def __setitem__(self, key, value):
         self._slots[key] = value
@@ -51,8 +63,23 @@ class _ProgressReport:
             processed, _verified, total, step = value
         except (ValueError, TypeError):
             return
+        processed = int(processed)
+        total = int(total)
+        now = time.monotonic()
+        # Always let through the very first sample and the final one so the
+        # UI shows 0% and 100% exactly. Throttle everything in between.
+        is_first = self._last_processed < 0
+        is_final = total > 0 and processed >= total
+        if not is_first and not is_final:
+            if now - self._last_emit < _PROGRESS_THROTTLE_SECONDS:
+                return
+            if processed == self._last_processed and total == self._last_total:
+                return
+        self._last_emit = now
+        self._last_processed = processed
+        self._last_total = total
         try:
-            self._callback(str(step), int(processed), int(total))
+            self._callback(str(step), processed, total)
         except Exception:
             pass
 

--- a/src/utils/parallel_extract.py
+++ b/src/utils/parallel_extract.py
@@ -1,0 +1,139 @@
+"""
+Parallel ZIP extraction helper.
+
+Spawns a small pool of worker threads, each owning its own ``ZipFile``
+handle, so the underlying zlib decompressors (which release the GIL) can
+run concurrently on multi-core devices. Falls back to single-threaded
+extraction when there is only one member, only one worker, or the
+archive is too small to benefit.
+"""
+
+import os
+import queue
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Callable, Optional
+from zipfile import ZipFile, BadZipFile
+
+
+# Archives smaller than this run serially — the thread-pool setup cost
+# outweighs the parallel-decompress win on tiny inputs.
+_PARALLEL_MIN_BYTES = 8 * 1024 * 1024
+
+
+def parallel_extract_zip(
+    zip_path: str,
+    dest_dir: str,
+    on_progress: Optional[Callable[[int, int], None]] = None,
+    should_cancel: Optional[Callable[[], bool]] = None,
+    max_workers: int = 4,
+) -> bool:
+    """Extract a ZIP file using a pool of ``ZipFile`` handles in parallel.
+
+    Args:
+        zip_path: Path to the ZIP file.
+        dest_dir: Output directory (created if missing).
+        on_progress: Optional ``(bytes_written, bytes_total)`` callback.
+            Called from worker threads as each member finishes.
+        should_cancel: Optional ``() -> bool`` polled per member.
+            When it returns True the extraction aborts.
+        max_workers: Maximum worker threads. Capped to the number of
+            members so we don't spin idle threads.
+
+    Returns:
+        True on success, False if cancelled or on unrecoverable error.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+
+    try:
+        with ZipFile(zip_path, "r") as zf:
+            members = zf.infolist()
+    except BadZipFile:
+        return False
+
+    total_bytes = sum(m.file_size for m in members) or 1
+
+    workers = max(1, min(max_workers, len(members)))
+    if total_bytes < _PARALLEL_MIN_BYTES or workers == 1:
+        return _serial_extract(zip_path, dest_dir, members, total_bytes, on_progress, should_cancel)
+
+    handle_pool: "queue.Queue[ZipFile]" = queue.Queue()
+    handles = []
+    try:
+        for _ in range(workers):
+            zh = ZipFile(zip_path, "r")
+            handles.append(zh)
+            handle_pool.put(zh)
+    except Exception:
+        for h in handles:
+            try:
+                h.close()
+            except Exception:
+                pass
+        return False
+
+    written_lock = threading.Lock()
+    written = [0]
+    cancel_event = threading.Event()
+    error_event = threading.Event()
+
+    def worker(member):
+        if cancel_event.is_set() or error_event.is_set():
+            return
+        if should_cancel and should_cancel():
+            cancel_event.set()
+            return
+        zh = handle_pool.get()
+        try:
+            zh.extract(member, dest_dir)
+            with written_lock:
+                written[0] += member.file_size
+                if on_progress:
+                    on_progress(written[0], total_bytes)
+        except Exception:
+            error_event.set()
+        finally:
+            handle_pool.put(zh)
+
+    try:
+        # Largest first keeps the workers saturated past the tail.
+        ordered = sorted(members, key=lambda m: m.file_size, reverse=True)
+        executor = ThreadPoolExecutor(max_workers=workers)
+        try:
+            futures = [executor.submit(worker, m) for m in ordered]
+            for _ in as_completed(futures):
+                if cancel_event.is_set() or error_event.is_set():
+                    break
+        finally:
+            executor.shutdown(wait=True, cancel_futures=True)
+    finally:
+        for h in handles:
+            try:
+                h.close()
+            except Exception:
+                pass
+
+    if cancel_event.is_set() or error_event.is_set():
+        return False
+    return True
+
+
+def _serial_extract(
+    zip_path: str,
+    dest_dir: str,
+    members,
+    total_bytes: int,
+    on_progress,
+    should_cancel,
+) -> bool:
+    """Single-threaded fallback when parallelism isn't worth the overhead."""
+    with ZipFile(zip_path, "r") as zf:
+        written = 0
+        for m in members:
+            if should_cancel and should_cancel():
+                return False
+            zf.extract(m, dest_dir)
+            written += m.file_size
+            if on_progress:
+                on_progress(written, total_bytes)
+    return True

--- a/src/utils/progress.py
+++ b/src/utils/progress.py
@@ -1,0 +1,74 @@
+"""
+Smoothed speed/ETA tracker for long-running operations (extraction, etc).
+
+Keeps a sliding window of (timestamp, bytes_processed) samples and exposes
+an averaged throughput. Designed to mirror the speed-tracking pattern used
+by the download path so the same UI ("123 MB/s - 12s") works during
+extraction phases as well.
+"""
+
+import time
+from typing import List, Tuple
+
+
+class SpeedTracker:
+    """Track speed and ETA from a stream of cumulative byte counts."""
+
+    def __init__(self, max_samples: int = 5, sample_interval: float = 0.5):
+        self._max_samples = max_samples
+        self._sample_interval = sample_interval
+        self._samples: List[Tuple[float, int]] = []
+        self._speed: float = 0.0
+        self._last_emit: float = 0.0
+        self._last_processed: int = 0
+
+    def reset(self):
+        """Reset back to zero. Call at the start of a new phase."""
+        self._samples.clear()
+        self._speed = 0.0
+        self._last_emit = 0.0
+        self._last_processed = 0
+
+    def update(self, processed: int) -> float:
+        """Record a new cumulative processed-bytes value. Returns smoothed speed."""
+        now = time.time()
+        if not self._samples:
+            self._samples.append((now, processed))
+            self._last_emit = now
+            self._last_processed = processed
+            return 0.0
+
+        elapsed = now - self._last_emit
+        if elapsed < self._sample_interval:
+            return self._speed
+
+        dt = now - self._samples[-1][0]
+        if dt > 0:
+            instant = (processed - self._samples[-1][1]) / dt
+            self._samples.append((now, processed))
+            if len(self._samples) > self._max_samples:
+                self._samples.pop(0)
+            # Smoothed: average of (instant + previous samples)
+            if len(self._samples) >= 2:
+                first_t, first_b = self._samples[0]
+                window_dt = now - first_t
+                self._speed = (
+                    (processed - first_b) / window_dt if window_dt > 0 else instant
+                )
+            else:
+                self._speed = instant
+
+        self._last_emit = now
+        self._last_processed = processed
+        return self._speed
+
+    @property
+    def speed(self) -> float:
+        return self._speed
+
+    @staticmethod
+    def eta_seconds(total: int, processed: int, speed: float) -> int:
+        """Compute remaining seconds, or 0 if unknown."""
+        if speed <= 0 or total <= 0 or processed >= total:
+            return 0
+        return max(0, int((total - processed) / speed))


### PR DESCRIPTION
The Android DownloadService probed content-length/accept-ranges with a
HEAD request after manually resolving redirects. Some auth-protected
servers reject HEAD (returning 401), and when HEAD followed a cross-host
redirect, requests stripped Authorization so the resolved URL was no
longer reachable with the same credentials. This forced users to enable
the Python downloader as a workaround.

Mirror the desktop DownloadManager: use a single streaming GET (with
manual redirect-following when auth is present) to both resolve the URL
and read content-length/accept-ranges. Drops the now-unused
_resolve_redirects helper.