### PR TITLE
fix(android-build): bump pyjnius to 1.7.0 to match p4a recipe

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -6,7 +6,7 @@ source.dir = .
 source.include_exts = py,png,jpg,kv,atlas,json,ttf
 source.include_patterns = src/**/*.py,assets/**/*,recipes/**/*
 version = 0.1
-requirements = python3==3.10.12,kivy==2.3.0,pyjnius==1.5.0,hostpython3==3.10.12,pygame,requests,certifi,rarfile,zstandard==0.21.0,pycryptodome,jnius,android
+requirements = python3==3.10.12,kivy==2.3.0,pyjnius==1.7.0,hostpython3==3.10.12,pygame,requests,certifi,rarfile,zstandard==0.21.0,pycryptodome,jnius,android
 orientation = landscape, portrait
 osx.python_version = 3
 osx.kivy_version = 1.9.1


### PR DESCRIPTION
The p4a master pyjnius recipe targets version 1.7.0 and applies a
use_cython.patch that touches PYX_FILES. Pinning pyjnius==1.5.0 made
patch -t (batch mode) detect the unrelated FILES variable as a
"Reversed" patch and apply it backwards, injecting a stray reference
to undefined PYX_FILES at line 66 of setup.py and breaking the wheel
build.

https://claude.ai/code/session_019raXjpJDVR5xaCR7fdWFEM