### PR TITLE
fix: Android keyboard and URL download fixes (GAB-13, GAB-14)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5867,6 +5867,21 @@ class ConsoleUtilitiesApp:
                     self.state.syncthing.custom_name_input = name
                     # Open folder browser to pick source folder
                     self._open_folder_browser("custom_save_source")
+            elif self.state.url_input.context == "direct_download":
+                url = self.state.url_input.input_text.strip()
+                self.state.url_input.show = False
+                if url:
+                    # Add URL as a direct download job
+                    from services.download_manager import DownloadQueueItem
+
+                    item = DownloadQueueItem(
+                        game={"url": url, "name": url.split("/")[-1] or "download"},
+                        system_data={},
+                        system_name="Direct URL",
+                        status="waiting",
+                    )
+                    self.download_manager.queue.items.append(item)
+                    self.state.mode = "downloads"
             else:
                 self.state.url_input.show = False
 
@@ -6434,6 +6449,8 @@ class ConsoleUtilitiesApp:
             or self.state.folder_name_input.show
             or self.state.url_input.show
             or self.state.ia_login.show
+            or self.state.ia_download_wizard.show
+            or self.state.ia_collection_wizard.show
             or self.state.scraper_login.show
             or (
                 self.state.auth_token_input.show


### PR DESCRIPTION
## Summary
- GAB-13: Add `ia_download_wizard.show` and `ia_collection_wizard.show` to `_is_text_modal_open()` so the Android soft keyboard opens when these Internet Archive modals are active
- GAB-14: Handle `context=='direct_download'` in `_handle_url_input_selection()` to actually start a download when a URL is submitted from the file utilities (previously just closed the modal without starting anything)

## Root Causes
- GAB-13: `_is_text_modal_open()` checked for `ia_login` and `scraper_login` but missed `ia_download_wizard` and `ia_collection_wizard` modals
- GAB-14: The `else` clause in `_handle_url_input_selection()` only called `self.state.url_input.show = False` without queuing the download

Closes #GAB-13
Closes #GAB-14