### PR TITLE
fix: review bundled data sources and add Minerva API support (GAB-15)

### DIFF
--- a/assets/bundled_data.json
+++ b/assets/bundled_data.json
@@ -1,0 +1,111 @@
+[
+  {
+    "name": "Myrient Sony PlayStation (PSX)",
+    "url": "https://myrient.erista.me/files/No-Intro/Sony%20-%20PlayStation/",
+    "regex": "<tr><td class=\"link\"><a href=\"(?P<href>[^\"]+)\" title=\"(?P<title>[^\"]+)\">(?P<text>[^<]+)</a></td><td class=\"size\">(?P<size>[^<]+)</td><td class=\"date\">[^<]*</td></tr>",
+    "file_format": [".zip", ".cue", ".bin", ".iso"],
+    "roms_folder": "psx",
+    "boxarts": "https://thumbnails.libretro.com/Sony%20-%20PlayStation/Named_Boxarts/",
+    "should_unzip": false,
+    "source": "myrient",
+    "description": "Sony PlayStation ROMs from Myrient (No-Intro set)"
+  },
+  {
+    "name": "Myrient Super Nintendo (SNES)",
+    "url": "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Super%20Nintendo%20Entertainment%20System/",
+    "regex": "<tr><td class=\"link\"><a href=\"(?P<href>[^\"]+)\" title=\"(?P<title>[^\"]+)\">(?P<text>[^<]+)</a></td><td class=\"size\">(?P<size>[^<]+)</td><td class=\"date\">[^<]*</td></tr>",
+    "file_format": [".sfc", ".smc", ".zip"],
+    "roms_folder": "snes",
+    "boxarts": "https://thumbnails.libretro.com/Nintendo%20-%20Super%20Nintendo%20Entertainment%20System/Named_Boxarts/",
+    "should_unzip": true,
+    "extract_contents": true,
+    "source": "myrient",
+    "description": "Super Nintendo ROMs from Myrient (No-Intro set)"
+  },
+  {
+    "name": "Myrient Nintendo 64 (N64)",
+    "url": "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Nintendo%2064/",
+    "regex": "<tr><td class=\"link\"><a href=\"(?P<href>[^\"]+)\" title=\"(?P<title>[^\"]+)\">(?P<text>[^<]+)</a></td><td class=\"size\">(?P<size>[^<]+)</td><td class=\"date\">[^<]*</td></tr>",
+    "file_format": [".zip", ".n64", ".v64"],
+    "roms_folder": "n64",
+    "boxarts": "https://thumbnails.libretro.com/Nintendo%20-%20Nintendo%2064/Named_Boxarts/",
+    "should_unzip": true,
+    "extract_contents": true,
+    "source": "myrient",
+    "description": "Nintendo 64 ROMs from Myrient (No-Intro set)"
+  },
+  {
+    "name": "Myrient Game Boy Advance (GBA)",
+    "url": "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Game%20Boy%20Advance/",
+    "regex": "<tr><td class=\"link\"><a href=\"(?P<href>[^\"]+)\" title=\"(?P<title>[^\"]+)\">(?P<text>[^<]+)</a></td><td class=\"size\">(?P<size>[^<]+)</td><td class=\"date\">[^<]*</td></tr>",
+    "file_format": [".zip", ".gba"],
+    "roms_folder": "gba",
+    "boxarts": "https://thumbnails.libretro.com/Nintendo%20-%20Game%20Boy%20Advance/Named_Boxarts/",
+    "should_unzip": true,
+    "extract_contents": true,
+    "source": "myrient",
+    "description": "Game Boy Advance ROMs from Myrient (No-Intro set)"
+  },
+  {
+    "name": "Myrient Sega Genesis",
+    "url": "https://myrient.erista.me/files/No-Intro/Sega%20-%20Mega%20Drive%20-%20Genesis/",
+    "regex": "<tr><td class=\"link\"><a href=\"(?P<href>[^\"]+)\" title=\"(?P<title>[^\"]+)\">(?P<text>[^<]+)</a></td><td class=\"size\">(?P<size>[^<]+)</td><td class=\"date\">[^<]*</td></tr>",
+    "file_format": [".zip", ".bin", ".md", ".gen"],
+    "roms_folder": "genesis",
+    "boxarts": "https://thumbnails.libretro.com/Sega%20-%20Mega%20Drive%20-%20Genesis/Named_Boxarts/",
+    "should_unzip": true,
+    "extract_contents": true,
+    "source": "myrient",
+    "description": "Sega Genesis/Mega Drive ROMs from Myrient (No-Intro set)"
+  },
+  {
+    "name": "Myrient GameCube",
+    "url": "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20GameCube/",
+    "regex": "<tr><td class=\"link\"><a href=\"(?P<href>[^\"]+)\" title=\"(?P<title>[^\"]+)\">(?P<text>[^<]+)</a></td><td class=\"size\">(?P<size>[^<]+)</td><td class=\"date\">[^<]*</td></tr>",
+    "file_format": [".zip", ".iso", ".gcm"],
+    "roms_folder": "gc",
+    "boxarts": "https://thumbnails.libretro.com/Nintendo%20-%20GameCube/Named_Boxarts/",
+    "should_unzip": true,
+    "extract_contents": true,
+    "source": "myrient",
+    "description": "Nintendo GameCube ROMs from Myrient (No-Intro set)"
+  },
+  {
+    "name": "Myrient Nintendo DS",
+    "url": "https://myrient.erista.me/files/No-Intro/Nintendo%20-%20Nintendo%20DS/",
+    "regex": "<tr><td class=\"link\"><a href=\"(?P<href>[^\"]+)\" title=\"(?P<title>[^\"]+)\">(?P<text>[^<]+)</a></td><td class=\"size\">(?P<size>[^<]+)</td><td class=\"date\">[^<]*</td></tr>",
+    "file_format": [".zip", ".nds"],
+    "roms_folder": "nds",
+    "boxarts": "https://thumbnails.libretro.com/Nintendo%20-%20Nintendo%20DS/Named_Boxarts/",
+    "should_unzip": true,
+    "extract_contents": true,
+    "source": "myrient",
+    "description": "Nintendo DS ROMs from Myrient (No-Intro set)"
+  },
+  {
+    "name": "Myrient PSP",
+    "url": "https://myrient.erista.me/files/No-Intro/Sony%20-%20PlayStation%20Portable/",
+    "regex": "<tr><td class=\"link\"><a href=\"(?P<href>[^\"]+)\" title=\"(?P<title>[^\"]+)\">(?P<text>[^<]+)</a></td><td class=\"size\">(?P<size>[^<]+)</td><td class=\"date\">[^<]*</td></tr>",
+    "file_format": [".zip", ".iso", ".cso"],
+    "roms_folder": "psp",
+    "boxarts": "https://thumbnails.libretro.com/Sony%20-%20PlayStation%20Portable/Named_Boxarts/",
+    "should_unzip": false,
+    "source": "myrient",
+    "description": "Sony PSP ROMs from Myrient (No-Intro set)"
+  },
+  {
+    "name": "Minerva API - Game Metadata",
+    "list_url": "https://api.minerva-project.org/games",
+    "list_json_file_location": "games",
+    "list_item_id": "filename",
+    "file_format": [".zip", ".7z", ".rar"],
+    "roms_folder": "minerva",
+    "source_type": "minerva_api",
+    "source": "minerva",
+    "description": "Minerva API - Game metadata and ROM data via JSON API with API key authentication",
+    "auth": {
+      "type": "minerva_api_key",
+      "api_key": ""
+    }
+  }
+]

--- a/docs/bundled-data-sources.md
+++ b/docs/bundled-data-sources.md
@@ -1,0 +1,126 @@
+# Bundled Data Sources
+
+Console Utilities ships with a `bundled_data.json` file in the `assets/` directory that contains pre-configured game system sources. These provide out-of-the-box access to popular ROM data sources.
+
+## Current Bundled Sources
+
+### Myrient (HTML Directory Listing)
+
+Myrient is a popular ROM hosting service that provides No-Intro and Redump verified ROM sets. The bundled data includes:
+
+| System | ROMs Folder | Formats | Auto-Extract |
+|--------|-------------|---------|--------------|
+| Sony PlayStation (PSX) | `psx` | .zip, .cue, .bin, .iso | No |
+| Super Nintendo (SNES) | `snes` | .sfc, .smc, .zip | Yes |
+| Nintendo 64 (N64) | `n64` | .zip, .n64, .v64 | Yes |
+| Game Boy Advance (GBA) | `gba` | .zip, .gba | Yes |
+| Sega Genesis | `genesis` | .zip, .bin, .md, .gen | Yes |
+| GameCube | `gc` | .zip, .iso, .gcm | Yes |
+| Nintendo DS | `nds` | .zip, .nds | Yes |
+| PlayStation Portable (PSP) | `psp` | .zip, .iso, .cso | No |
+
+All Myrient sources use Libretro thumbnails for box art.
+
+### Minerva API
+
+Minerva is a JSON-based API source type that provides game metadata and ROM data. It supports:
+
+- **API Key Authentication**: Uses `X-Minerva-API-Key` header
+- **Flexible Response Parsing**: Configure `list_json_file_location` and `list_item_id`
+- **File Filtering**: Filter by format extensions
+- **Custom Download URLs**: Use `download_url` template with `<id>` placeholder
+
+#### Minerva API Configuration
+
+```json
+{
+  "name": "My Minerva Collection",
+  "list_url": "https://api.minerva-project.org/games",
+  "list_json_file_location": "games",
+  "list_item_id": "filename",
+  "list_item_size": "size",
+  "download_url": "https://api.minerva-project.org/download/<id>",
+  "file_format": [".zip", ".7z"],
+  "roms_folder": "minerva_roms",
+  "source_type": "minerva_api",
+  "auth": {
+    "type": "minerva_api_key",
+    "api_key": "your-api-key-here"
+  }
+}
+```
+
+## Adding Custom Sources
+
+### Via the App
+
+1. Go to **Settings > Add Systems**
+2. Browse available systems or add a custom source
+3. For Internet Archive: Use the IA Collection wizard
+4. For custom URLs: Use the folder browser to configure
+
+### Via JSON Configuration
+
+Edit `added_systems.json` (in `workdir/` for development, or app directory for console):
+
+```json
+[
+  {
+    "name": "Custom System",
+    "url": "https://your-server.com/roms/",
+    "file_format": [".zip"],
+    "roms_folder": "custom",
+    "should_unzip": true
+  }
+]
+```
+
+## Source Types
+
+| Type | Configuration | Description |
+|------|---------------|-------------|
+| HTML | `url` field | Directory listing with optional regex |
+| Internet Archive | `url` with `archive.org/download/` | IA metadata API |
+| JSON API | `list_url` field | Structured JSON response |
+| NPS TSV | `source_type: nps_tsv` | Nintendo PSX TSV format |
+| Minerva API | `source_type: minerva_api` | Custom JSON API with auth |
+
+## Best Game Data Sources
+
+### ROM Sources
+
+1. **Myrient** - No-Intro and Redump sets, clean filenames, reliable
+2. **Internet Archive** - Various ROM collections, often with metadata
+3. **Custom Servers** - Your own hosted ROMs
+
+### Metadata Sources
+
+1. **Libretro Thumbnails** - Box art, screenshots, titles, logos
+2. **ScreenScraper** - Detailed metadata and artwork (requires credentials)
+3. **TheGamesDB** - Game metadata and box art
+4. **RAWG** - Large game database with artwork
+
+### API Sources
+
+For programmatic access to game data, consider:
+
+1. **Minerva API** - If you have an API key for a Minerva-based service
+2. **Custom JSON APIs** - Any API returning structured JSON can be integrated
+3. **Internet Archive API** - Direct metadata access for IA collections
+
+## Updating Bundled Sources
+
+The `bundled_data.json` file in `assets/` is overwritten on app updates. For persistent customizations:
+
+1. Add systems to `added_systems.json` instead
+2. Or set `archive_json_path` in settings to a custom JSON file
+3. Use the IA collection wizard for one-off additions
+
+## Authentication
+
+| Auth Type | Configuration | Header/Cookie |
+|-----------|---------------|---------------|
+| Bearer Token | `{"token": "..."}` | `Authorization: Bearer ...` |
+| Cookie | `{"cookies": true, "token": "...", "cookie_name": "..."}` | Cookie header |
+| IA S3 | `{"type": "ia_s3", "access_key": "...", "secret_key": "..."}` | `Authorization: LOW ...` |
+| Minerva API Key | `{"type": "minerva_api_key", "api_key": "..."}` | `X-Minerva-API-Key: ...` |

--- a/src/services/file_listing.py
+++ b/src/services/file_listing.py
@@ -249,6 +249,10 @@ def list_files(
         if system_data.get("source_type") == "nps_tsv":
             return _list_files_nps_tsv(system_data, settings)
 
+        # Check if this is a Minerva API source
+        if system_data.get("source_type") == "minerva_api":
+            return _list_files_minerva_api(system_data, settings, formats)
+
         # Check if this is the JSON API format
         if "list_url" in system_data:
             return _list_files_json_api(system_data, settings, formats)
@@ -450,6 +454,125 @@ def _list_files_json_api(
             return filtered_files
 
     return []
+
+
+def _list_files_minerva_api(
+    system_data: Dict[str, Any], settings: Dict[str, Any], formats: List[str]
+) -> List[Dict[str, Any]]:
+    """
+    List files from Minerva API source.
+
+    Minerva API is a JSON-based API for game ROM data that supports:
+    - API key authentication
+    - Flexible response parsing (specify array path and item ID key)
+    - File filtering by format
+    - Optional download URL construction from file ID
+
+    Args:
+        system_data: System configuration
+        settings: Application settings
+        formats: Allowed file formats
+
+    Returns:
+        List of file dictionaries with filename, href, and size
+    """
+    list_url = system_data.get("list_url")
+    if not list_url:
+        log_error("Minerva API: No list_url configured", "MinervaAPIError", "")
+        return []
+
+    cached = _load_cached_listing(list_url)
+    if cached is not None:
+        return cached
+
+    # Build headers
+    headers = {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Accept": "application/json",
+    }
+    cookies = {}
+
+    # Check for Minerva API key authentication
+    if "auth" in system_data:
+        auth_config = system_data["auth"]
+        if auth_config.get("type") == "minerva_api_key":
+            api_key = auth_config.get("api_key") or auth_config.get("token", "")
+            if api_key:
+                headers["X-Minerva-API-Key"] = api_key
+        elif "token" in auth_config:
+            # Bearer token fallback
+            headers["Authorization"] = f"Bearer {auth_config['token']}"
+
+    try:
+        r = requests.get(list_url, timeout=(10, 30), headers=headers, cookies=cookies)
+    except (requests.exceptions.SSLError, requests.exceptions.ConnectionError):
+        r = requests.get(
+            list_url, timeout=(10, 30), headers=headers, cookies=cookies, verify=False
+        )
+    response = r.json()
+
+    # Parse response based on configured paths
+    array_path = system_data.get("list_json_file_location", "files")
+    file_id = system_data.get("list_item_id", "name")
+    size_key = system_data.get("list_item_size", "size")
+    href_template = system_data.get("download_url", "")
+
+    # Navigate to the files array (supports dot notation like "data.games")
+    files = response
+    for key in array_path.split("."):
+        if isinstance(files, dict):
+            files = files.get(key, [])
+        else:
+            files = []
+            break
+
+    if not isinstance(files, list):
+        log_error("Minerva API: Invalid response format", "MinervaAPIError", "")
+        return []
+
+    result = []
+    for f in files:
+        if not isinstance(f, dict):
+            continue
+
+        filename = f.get(file_id, "")
+        if not filename:
+            continue
+
+        # Filter by format
+        ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+        if formats and ext not in [fmt.lower() for fmt in formats]:
+            continue
+
+        # Get file size
+        size = 0
+        if size_key in f:
+            try:
+                size = int(f[size_key])
+            except (ValueError, TypeError):
+                size = 0
+
+        # Build download URL
+        href = ""
+        if href_template:
+            # Replace <id> placeholder with file ID
+            file_id_value = f.get("id", filename)
+            href = href_template.replace("<id>", str(file_id_value))
+        elif "href" in f:
+            href = f["href"]
+        elif "url" in f:
+            href = f["url"]
+
+        result.append({
+            "filename": filename,
+            "href": href,
+            "size": size,
+        })
+
+    result.sort(key=lambda x: x.get("filename", ""))
+    if result:
+        _save_listing_cache(list_url, result)
+    return result
 
 
 def _list_files_html(


### PR DESCRIPTION
## Summary
- Reviews bundled data sources in the console utilities app
- Adds Minerva API as a downloadable source type
- Creates `assets/bundled_data.json` with Myrient HTML sources and Minerva API template
- Updates `file_listing.py` with `_list_files_minerva_api()` function
- Documents all bundled sources in `docs/bundled-data-sources.md`

Closes #GAB-15