### PR TITLE
Fix GAB-10: NSZ decompression fails on Android above 3 GB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ platforms
 system-images
 .superpowers
 docs/superpowers
+# Local dev virtualenv (squad pipeline)
+.venv/

--- a/src/droid/storage.py
+++ b/src/droid/storage.py
@@ -1,6 +1,7 @@
 """Android external storage utilities."""
 
 import os
+import sys
 
 
 def get_external_data_dir(fallback: str) -> str:
@@ -17,6 +18,16 @@ def get_external_data_dir(fallback: str) -> str:
         ext_dir = context.getExternalFilesDir(None)
         if ext_dir:
             return ext_dir.getAbsolutePath()
-    except Exception:
-        pass
-    return fallback
+        print(
+            "get_external_data_dir: external dir is null, using fallback",
+            file=sys.stderr,
+            flush=True,
+        )
+        return fallback
+    except Exception as e:
+        print(
+            f"get_external_data_dir: JNI failed ({e}), using fallback",
+            file=sys.stderr,
+            flush=True,
+        )
+        return fallback

--- a/src/nsz/Fs/Pfs0.py
+++ b/src/nsz/Fs/Pfs0.py
@@ -29,6 +29,21 @@ class Pfs0Stream(BaseFile):
 		self.f.seek(self.headerSize)
 		self.addpos = self.headerSize
 		self.written = False
+		self._bytesSinceSync = 0
+		self._FSYNC_INTERVAL = 256 * 1024 * 1024
+
+	def _sync(self):
+		if self.f is None:
+			return
+		try:
+			self.f.flush()
+			os.fsync(self.f.fileno())
+		except (OSError, ValueError) as e:
+			try:
+				from utils.logging import log_error
+				log_error(f"Pfs0Stream fsync failed: {e}")
+			except Exception:
+				pass
 
 	def __enter__(self):
 		return self
@@ -42,6 +57,10 @@ class Pfs0Stream(BaseFile):
 		pos = self.tell()
 		if pos > self.actualSize:
 			self.actualSize = pos
+		self._bytesSinceSync += len(value)
+		if self._bytesSinceSync >= self._FSYNC_INTERVAL:
+			self._sync()
+			self._bytesSinceSync = 0
 
 	def add(self, name, size, pleaseNoPrint = None):
 		if self.written:
@@ -70,6 +89,7 @@ class Pfs0Stream(BaseFile):
 		if self.isOpen():
 			self.seek(0)
 			self.write(self.getHeader())
+			self._sync()
 			super(Pfs0Stream, self).close()
 
 	#0xff => 0x1, 0x100 => 0x20, 0x1ff => 0x1, 0x120 => 0x20

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -5,6 +5,7 @@ Provides logging with timestamps, file output, and stdout mirroring.
 
 import os
 import sys
+import tempfile
 from datetime import datetime
 from typing import Optional
 
@@ -17,6 +18,25 @@ _log_file: str = os.path.join(TEMP_LOG_DIR, "error.log")
 def get_log_file() -> str:
     """Get the current log file path."""
     return _log_file
+
+
+def _write_fallback(text: str) -> None:
+    """Best-effort write of a log entry to a fallback location.
+
+    Tries the system temp dir first, then the current directory. Never raises;
+    surfaces failures to stderr and stops after the first success.
+    """
+    candidates = [
+        os.path.join(tempfile.gettempdir(), "console_utilities_error.log"),
+        os.path.join(".", "error.log"),
+    ]
+    for path in candidates:
+        try:
+            with open(path, "a") as f:
+                f.write(text)
+            return
+        except OSError as e:
+            print(f"Failed to write fallback log to {path}: {e}", file=sys.stderr, flush=True)
 
 
 def log_error(
@@ -53,8 +73,9 @@ def log_error(
     try:
         with open(_log_file, "a") as f:
             f.write(file_message)
-    except Exception:
-        pass
+    except OSError as e:
+        print(f"Failed to write log to {_log_file}: {e}", file=sys.stderr, flush=True)
+        _write_fallback(file_message)
 
 
 def init_log_file() -> bool:
@@ -82,4 +103,5 @@ def init_log_file() -> bool:
 
     except Exception as e:
         print(f"Failed to initialize log file: {e}")
+        print(f"Failed to initialize log file: {e}", file=sys.stderr, flush=True)
         return False

--- a/src/utils/nsz.py
+++ b/src/utils/nsz.py
@@ -28,6 +28,65 @@ def is_nsz_available() -> bool:
     return NSZ_AVAILABLE
 
 
+def _detect_fs_type(path: str) -> Optional[str]:
+    """Detect the filesystem type backing ``path`` by parsing /proc/mounts.
+
+    Returns the lowercase fstype of the longest mountpoint that is a prefix of
+    the absolute path, or None on any failure (file unreadable / non-Linux).
+    """
+    try:
+        abspath = os.path.abspath(path)
+        best_mount = ""
+        best_fstype = None
+        with open("/proc/mounts", "r") as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) < 3:
+                    continue
+                mountpoint, fstype = parts[1], parts[2]
+                if abspath == mountpoint or abspath.startswith(
+                    mountpoint.rstrip("/") + "/"
+                ) or mountpoint == "/":
+                    if len(mountpoint) >= len(best_mount):
+                        best_mount = mountpoint
+                        best_fstype = fstype
+        return best_fstype.lower() if best_fstype is not None else None
+    except Exception:
+        return None
+
+
+def check_output_capacity(output_dir: str, required_bytes: int):
+    """Pre-flight check that ``output_dir`` can hold ``required_bytes``.
+
+    Returns (ok, reason). ``reason`` is None when ok. Fails open (returns True)
+    when free space cannot be determined.
+    """
+    try:
+        st = os.statvfs(output_dir)
+        free = st.f_frsize * st.f_bavail
+    except OSError:
+        return (True, None)  # fail-open: can't tell, don't block
+
+    fs = _detect_fs_type(output_dir)
+    if fs in {"vfat", "msdos", "fat", "fat32"} and required_bytes >= 4 * 1024 ** 3 - 1:
+        return (
+            False,
+            "Target drive is FAT32, which cannot store a single file of 4 GB "
+            "or larger. Reformat the drive as exFAT and try again.",
+        )
+
+    if required_bytes > free:
+        need_gb = required_bytes / (1024 ** 3)
+        have_gb = free / (1024 ** 3)
+        return (
+            False,
+            f"Not enough free space: need ~{need_gb:.1f} GB but only "
+            f"{have_gb:.1f} GB available.",
+        )
+
+    return (True, None)
+
+
 def decompress_nsz_file(
     nsz_file_path: str,
     output_dir: str,
@@ -87,6 +146,17 @@ def decompress_nsz_file(
                 raise ValueError(f"NSZ file is empty: {nsz_file_path}")
 
             log_error(f"Attempting NSZ decompression of {filename} ({file_size} bytes)")
+
+            # Pre-flight capacity check: decompressed NSP roughly doubles the
+            # NSZ size. Block before extraction when the target can't hold it
+            # (FAT32 4 GB limit or insufficient free space) so we fail loudly
+            # rather than silently truncating a multi-GiB extraction.
+            est_output = file_size * 2
+            ok, reason = check_output_capacity(output_dir, est_output)
+            if not ok:
+                log_error(f"Capacity check failed for {filename}: {reason}")
+                update_progress(reason, 0)
+                return False
 
             # Translate library's (done_bytes, total_bytes) into our (message, percent).
             # Throttle by integer-percent change so we don't flood IPC writes.

--- a/tests/test_droid_storage.py
+++ b/tests/test_droid_storage.py
@@ -1,0 +1,49 @@
+"""TDD (red) tests for GAB-10: Android external storage resolution.
+
+get_external_data_dir falls back silently when the JNI call fails or when
+getExternalFilesDir returns null. A silent fallback to app-private storage is
+exactly how a large extraction ends up on the wrong (smaller) volume without
+any diagnostic. These tests require a stderr warning on every fallback.
+
+Pinned NOT-YET-IMPLEMENTED behavior in droid.storage:
+    - On JNI failure -> return fallback AND warn on stderr.
+    - On null external dir -> return fallback AND warn on stderr.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.argv = sys.argv[:1]
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from droid import storage  # noqa: E402
+
+
+def test_returns_fallback_and_warns_on_jni_failure(monkeypatch, capsys):
+    # Ensure jnius is unavailable so the import inside the function raises.
+    monkeypatch.setitem(sys.modules, "jnius", None)
+
+    result = storage.get_external_data_dir("/my/fallback")
+
+    captured = capsys.readouterr()
+    assert result == "/my/fallback"
+    assert "fallback" in captured.err.lower()
+
+
+def test_returns_fallback_when_ext_dir_null(monkeypatch, capsys):
+    context = SimpleNamespace(getExternalFilesDir=lambda arg: None)
+    activity = SimpleNamespace(getApplicationContext=lambda: context)
+    python_activity = SimpleNamespace(mActivity=activity)
+
+    fake_jnius = SimpleNamespace(autoclass=lambda name: python_activity)
+    monkeypatch.setitem(sys.modules, "jnius", fake_jnius)
+
+    result = storage.get_external_data_dir("/fb2")
+
+    captured = capsys.readouterr()
+    assert result == "/fb2"
+    assert "fallback" in captured.err.lower()

--- a/tests/test_logging_hardening.py
+++ b/tests/test_logging_hardening.py
@@ -1,0 +1,97 @@
+"""TDD (red) tests for GAB-10: hardened logging.
+
+When the primary log file is unwritable (Android external storage permission
+quirks), log_error today silently swallows the failure (`except: pass`), so the
+breadcrumb trail that would explain a failed >3 GiB extraction is lost.
+
+Pinned NOT-YET-IMPLEMENTED behavior in utils.logging:
+    - On primary write failure, fall back to a file under tempfile.gettempdir().
+    - If the fallback also fails, surface the failure to stderr (never raise).
+
+Regression preserved:
+    - log_error always prints the message to stdout.
+    - init_log_file returns False (not raise) on failure.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.argv = sys.argv[:1]
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from utils import logging as L  # noqa: E402
+
+
+def test_log_error_writes_to_configured_file(tmp_path, monkeypatch):
+    log_path = tmp_path / "error.log"
+    monkeypatch.setattr(L, "_log_file", str(log_path))
+
+    L.log_error("hi")
+
+    assert log_path.exists()
+    assert "hi" in log_path.read_text()
+
+
+def test_log_error_falls_back_on_unwritable_primary(tmp_path, monkeypatch):
+    import builtins
+
+    real_open = builtins.open
+    primary = str(tmp_path / "primary" / "error.log")
+    monkeypatch.setattr(L, "_log_file", primary)
+
+    def fake_open(path, *args, **kwargs):
+        if str(path) == primary:
+            raise OSError("read-only filesystem")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    fallback_dir = tmp_path / "fallback"
+    fallback_dir.mkdir()
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(fallback_dir))
+
+    L.log_error("boom")
+
+    contents = [
+        f.read_text()
+        for f in fallback_dir.iterdir()
+        if f.is_file()
+    ]
+    assert any("boom" in c for c in contents), "no fallback log written"
+
+
+def test_log_error_surfaces_to_stderr_on_failure(tmp_path, monkeypatch, capsys):
+    import builtins
+
+    def always_fail_open(path, *args, **kwargs):
+        raise OSError("everything is unwritable")
+
+    monkeypatch.setattr(builtins, "open", always_fail_open)
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(tmp_path))
+
+    # Must not raise even though primary AND fallback fail.
+    L.log_error("xyz")
+
+    captured = capsys.readouterr()
+    assert "fail" in captured.err.lower()
+
+
+def test_log_error_still_prints_stdout(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(L, "_log_file", str(tmp_path / "error.log"))
+
+    L.log_error("stdout-message")
+
+    captured = capsys.readouterr()
+    assert "stdout-message" in captured.out
+
+
+def test_init_log_file_returns_false_on_failure_without_raising(monkeypatch):
+    def boom(*args, **kwargs):
+        raise OSError("cannot create dir")
+
+    monkeypatch.setattr(os, "makedirs", boom)
+
+    assert L.init_log_file() is False

--- a/tests/test_nsz_capacity.py
+++ b/tests/test_nsz_capacity.py
@@ -1,0 +1,145 @@
+"""TDD (red) tests for GAB-10: output capacity / filesystem pre-flight checks.
+
+NSZ decompression on Android silently fails when the extracted NSP would
+exceed the free space available or the 4 GiB single-file limit of a FAT32
+target. These tests pin the NOT-YET-IMPLEMENTED API:
+
+    utils.nsz.check_output_capacity(output_dir, required_bytes) -> (ok, reason)
+    utils.nsz._detect_fs_type(path) -> str   (e.g. "vfat", "exfat", "ext4")
+    decompress_nsz_file must short-circuit (return False, never call the
+    underlying nsz decompressor) when check_output_capacity says no.
+
+The module imports cleanly today, so collection succeeds; the new symbols
+are accessed via the module object so the failures surface as AttributeError
+("feature not implemented yet"), not ImportError.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+# Keep nsz/ParseArguments out of pytest's argv when the nsz package imports.
+sys.argv = sys.argv[:1]
+
+# src on path so `utils` and the top-level `nsz` package resolve.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "nsz"))
+
+from utils import nsz as nsz_mod  # noqa: E402
+from utils.nsz import decompress_nsz_file  # noqa: E402
+
+GB = 1024 ** 3
+
+
+def _fake_statvfs(free_bytes, frsize=4096):
+    """Build an object shaped like os.statvfs_result with a given free size."""
+    bavail = free_bytes // frsize
+    return SimpleNamespace(
+        f_frsize=frsize,
+        f_bsize=frsize,
+        f_bavail=bavail,
+        f_bfree=bavail,
+        f_blocks=bavail,
+    )
+
+
+def test_capacity_ok_when_space_available(tmp_path, monkeypatch):
+    monkeypatch.setattr(os, "statvfs", lambda p: _fake_statvfs(50 * GB))
+    ok, reason = nsz_mod.check_output_capacity(str(tmp_path), 4 * GB)
+    assert ok is True
+    assert reason is None
+
+
+def test_capacity_fails_when_insufficient_space(tmp_path, monkeypatch):
+    monkeypatch.setattr(os, "statvfs", lambda p: _fake_statvfs(1 * GB))
+    ok, reason = nsz_mod.check_output_capacity(str(tmp_path), 4 * GB)
+    assert ok is False
+    assert reason is not None
+    assert "space" in reason.lower()
+
+
+def test_fat32_over_4gb_blocked(tmp_path, monkeypatch):
+    monkeypatch.setattr(nsz_mod, "_detect_fs_type", lambda p: "vfat", raising=False)
+    monkeypatch.setattr(os, "statvfs", lambda p: _fake_statvfs(50 * GB))
+    ok, reason = nsz_mod.check_output_capacity(str(tmp_path), 5 * GB)
+    assert ok is False
+    assert reason is not None
+    assert "fat32" in reason.lower()
+
+
+def test_fat32_under_4gb_allowed(tmp_path, monkeypatch):
+    monkeypatch.setattr(nsz_mod, "_detect_fs_type", lambda p: "vfat", raising=False)
+    monkeypatch.setattr(os, "statvfs", lambda p: _fake_statvfs(500 * GB))
+    ok, reason = nsz_mod.check_output_capacity(str(tmp_path), 3 * GB)
+    assert ok is True
+    assert reason is None
+
+
+def test_exfat_over_4gb_allowed(tmp_path, monkeypatch):
+    monkeypatch.setattr(nsz_mod, "_detect_fs_type", lambda p: "exfat", raising=False)
+    monkeypatch.setattr(os, "statvfs", lambda p: _fake_statvfs(500 * GB))
+    ok, reason = nsz_mod.check_output_capacity(str(tmp_path), 6 * GB)
+    assert ok is True
+    assert reason is None
+
+
+def test_capacity_fail_open_when_statvfs_raises(tmp_path, monkeypatch):
+    def boom(p):
+        raise OSError("statvfs unavailable")
+
+    monkeypatch.setattr(os, "statvfs", boom)
+    # Fail open: an unknowable filesystem must not block decompression.
+    ok, reason = nsz_mod.check_output_capacity(str(tmp_path), 4 * GB)
+    assert ok is True
+    assert reason is None
+
+
+def test_detect_fs_type_parses_proc_mounts(monkeypatch):
+    import builtins
+
+    real_open = builtins.open
+    mounts = "/dev/x /mnt/sd vfat rw 0 0\n/dev/y / ext4 rw 0 0\n"
+
+    def fake_open(path, *args, **kwargs):
+        if str(path) == "/proc/mounts":
+            import io
+
+            return io.StringIO(mounts)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    # Longest-prefix match: /mnt/sd is more specific than /.
+    assert nsz_mod._detect_fs_type("/mnt/sd/foo") == "vfat"
+    assert nsz_mod._detect_fs_type("/other") == "ext4"
+
+
+def test_decompress_short_circuits_on_capacity_fail(tmp_path, monkeypatch):
+    # Capacity check denies the operation.
+    monkeypatch.setattr(
+        nsz_mod,
+        "check_output_capacity",
+        lambda out_dir, required: (False, "FAT32 cannot hold a file this large"),
+        raising=False,
+    )
+
+    called = {"hit": False}
+
+    def must_not_run(*args, **kwargs):
+        called["hit"] = True
+        raise AssertionError("nsz decompressor must not be invoked")
+
+    # The internal decompress callable captured in utils/nsz.py.
+    monkeypatch.setattr(nsz_mod, "_nsz_decompress", must_not_run, raising=False)
+
+    nsz_file = tmp_path / "big.nsz"
+    nsz_file.write_bytes(b"\x00" * 1024)  # nonzero size so the size guard passes
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    result = decompress_nsz_file(str(nsz_file), str(out_dir), "/fake/keys.txt")
+
+    assert result is False
+    assert called["hit"] is False

--- a/tests/test_pfs0_fsync.py
+++ b/tests/test_pfs0_fsync.py
@@ -1,0 +1,143 @@
+"""TDD (red) tests for GAB-10: durable Pfs0 writes on Android.
+
+Multi-GiB extractions on Android external storage (exFAT/FUSE) get lost when
+the page cache is never flushed and a large pre-allocating truncate is issued.
+bfd1b05 already gates truncate above 2 GiB; this layer adds periodic + on-close
+fsync so written bytes actually hit disk.
+
+Pinned NOT-YET-IMPLEMENTED API on Pfs0Stream:
+    - self._FSYNC_INTERVAL: byte threshold between periodic fsyncs
+    - periodic os.fsync during write() once threshold is crossed
+    - os.fsync on close()
+    - self._sync(): swallows OSError, never propagates
+
+Regression preserved:
+    - updateHashHeader() truncates for final_size <= 2 GiB, never above it.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.argv = sys.argv[:1]
+
+# Pfs0 does `from nsz.nut import ...`, so src/nsz must be importable too.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "nsz"))
+
+from nsz.Fs.Pfs0 import Pfs0Stream  # noqa: E402
+
+HEADER = 0x100
+
+
+def _new_stream(tmp_path, name="game.nsp"):
+    path = tmp_path / "out" / name
+    return Pfs0Stream(HEADER, None, str(path)), path
+
+
+def test_periodic_fsync_called_on_large_write(tmp_path, monkeypatch):
+    stream, _ = _new_stream(tmp_path)
+    # Small interval so a modest write crosses it.
+    stream._FSYNC_INTERVAL = 1024
+
+    calls = []
+    monkeypatch.setattr(os, "fsync", lambda fd: calls.append(fd))
+
+    for _ in range(30):
+        stream.write(b"x" * 100)  # 3000 bytes total, well past 1024
+
+    assert len(calls) >= 1
+    stream.close()
+
+
+def test_no_fsync_for_small_writes(tmp_path, monkeypatch):
+    stream, _ = _new_stream(tmp_path)
+
+    calls = []
+    monkeypatch.setattr(os, "fsync", lambda fd: calls.append(fd))
+
+    stream.write(b"x" * 1024)  # tiny, under the default interval
+
+    assert len(calls) == 0
+    stream.close()
+
+
+def test_sync_on_close(tmp_path, monkeypatch):
+    stream, path = _new_stream(tmp_path)
+    content = b"HELLO-WORLD" * 8
+    stream.add("test.nca", len(content))
+    stream.write(content)
+
+    calls = []
+    monkeypatch.setattr(os, "fsync", lambda fd: calls.append(fd))
+
+    stream.close()
+
+    assert len(calls) >= 1
+    assert path.exists()
+    # File must be readable and start with a valid PFS0 header.
+    assert path.read_bytes()[:4] == b"PFS0"
+
+
+def test_sync_swallows_oserror(tmp_path, monkeypatch):
+    stream, path = _new_stream(tmp_path)
+
+    def raising_fsync(fd):
+        raise OSError("fsync not supported on this fs")
+
+    monkeypatch.setattr(os, "fsync", raising_fsync)
+
+    content = b"y" * 4096
+    stream.write(content)
+
+    # Triggering a sync must NOT propagate the OSError.
+    stream._sync()
+
+    stream.close()
+    assert path.exists()
+
+
+def test_truncate_still_used_for_small_files(tmp_path):
+    # Preserve bfd1b05: prealloc truncate for <=2GiB, skipped above it.
+    class FakeFile:
+        def __init__(self):
+            self.truncate_calls = []
+            self._pos = 0
+
+        def tell(self):
+            return self._pos
+
+        def seek(self, n, whence=0):
+            self._pos = n
+
+        def truncate(self, n):
+            self.truncate_calls.append(n)
+
+        def flush(self):
+            pass
+
+        def close(self):
+            pass
+
+    stream, _ = _new_stream(tmp_path)
+    real = stream.f  # the real file handle opened by the constructor
+
+    # --- small final size: truncate IS used ---
+    fake = FakeFile()
+    stream.f = fake
+    stream.offset = 0
+    stream.addpos = 1000
+    stream.updateHashHeader()
+    assert fake.truncate_calls == [1000]
+
+    # --- >2 GiB final size: truncate is NOT used ---
+    fake_big = FakeFile()
+    stream.f = fake_big
+    stream.addpos = 3 * 1024 * 1024 * 1024  # 3 GiB
+    stream.updateHashHeader()
+    assert fake_big.truncate_calls == []
+
+    # Cleanup: close the real handle, detach so __del__ is a no-op.
+    real.close()
+    stream.f = None


### PR DESCRIPTION
Closes GAB-10.

## Problem
NSZ→NSP extractions **> 3 GB fail silently on Android**, and the diagnostic `error.log` writes were swallowed, hiding the cause.

## Root cause
- `Pfs0Stream` never pre-allocated or synced large outputs. The 2 GiB truncate gate added in `bfd1b05` left 2–4 GB files with a single multi-GB buffered flush at `close()` on Android FUSE/exFAT — which dies silently mid-write.
- `log_error()` wrote inside a bare `except: pass` and `droid/storage.py` fell back silently → all NSZ breadcrumbs vanished on device, so the failure was invisible.

## Fix
- **`src/nsz/Fs/Pfs0.py`** — periodic `os.fsync()` every 256 MiB during `write()` + a final sync on `close()`. `_sync()` swallows `OSError`/`ValueError` and never raises. The existing `>2 GiB` truncate gate (bfd1b05) is preserved.
- **`src/utils/nsz.py`** — new `_detect_fs_type()` (parses `/proc/mounts`) and `check_output_capacity()` (free-space + FAT32 4 GB limit), **fail-open** so desktop/dev is never blocked. `decompress_nsz_file()` now refuses to start a doomed extraction with a clear, user-visible message.
- **`src/utils/logging.py`** — `log_error()` surfaces write failures to stderr and falls back to tempdir → cwd. Stdout path unchanged (web companion unaffected).
- **`src/droid/storage.py`** — report JNI/null fallback to stderr.

## Tests (TDD)
4 new files / 20 tests: `test_pfs0_fsync.py`, `test_nsz_capacity.py`, `test_logging_hardening.py`, `test_droid_storage.py`. **Full suite: 197 passed** (177 baseline + 20).

## ⚠️ On-device verification still needed
This was developed/tested on a Linux VM with no Android device. The pure-Python logic (fsync cadence, capacity/FAT32 checks, logging fallback) is unit-tested, but the **actual > 3 GB on-device extraction** and **scoped-storage `error.log` writes** must be confirmed on real Android hardware.

---
Delivered by the `console-utils-squad` pipeline: Research → CTO → Architect → Tester (TDD) → Developer → QA → PR.