### PR TITLE
Fix GAB-11: harden Nintendo Switch banner image loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ platforms
 system-images
 .superpowers
 docs/superpowers
+# Local dev virtualenv (squad pipeline)
+.venv/

--- a/src/services/image_cache.py
+++ b/src/services/image_cache.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import time
 import traceback
 from io import BytesIO
 from queue import Queue, Empty
@@ -20,6 +21,40 @@ import requests
 
 from utils.logging import log_error
 from constants import THUMBNAIL_SIZE, HIRES_IMAGE_SIZE, SYSTEMS_CACHE_DIR
+
+
+_PERMANENT_STATUSES = frozenset({400, 401, 403, 404, 410})
+
+
+def _make_image_session():
+    s = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(pool_connections=4, pool_maxsize=4)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s
+
+
+_image_session = _make_image_session()
+
+
+def _fetch_image_bytes(session, url, *, connect=5, read=15, attempts=3):
+    """Fetch raw image bytes with retry/backoff. Returns bytes on 2xx,
+    None on permanent status (400/401/403/404/410) or exhausted retries.
+    Retries on Timeout/ConnectionError/5xx."""
+    for attempt in range(attempts):
+        try:
+            resp = session.get(url, timeout=(connect, read))
+            if resp.status_code in _PERMANENT_STATUSES:
+                return None
+            resp.raise_for_status()
+            return resp.content
+        except requests.exceptions.HTTPError:
+            pass  # 5xx (4xx permanent already returned above) -> retry
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+            pass
+        if attempt < attempts - 1:
+            time.sleep(0.5 * (4 ** attempt))  # 0.5s, 2.0s
+    return None
 
 
 def _clean_name_for_matching(name: str) -> str:
@@ -472,15 +507,14 @@ class ImageCache:
         matched_url = self._resolve_thumbnail_url(base_url, base_name)
         if matched_url:
             try:
-                response = requests.get(matched_url, timeout=5)
-                response.raise_for_status()
+                content = _fetch_image_bytes(_image_session, matched_url)
+                if content is not None:
+                    image_data = BytesIO(content)
+                    image = pygame.image.load(image_data).convert_alpha()
+                    scaled_image = pygame.transform.smoothscale(image, target_size)
 
-                image_data = BytesIO(response.content)
-                image = pygame.image.load(image_data).convert_alpha()
-                scaled_image = pygame.transform.smoothscale(image, target_size)
-
-                queue.put((cache_key, scaled_image))
-                return
+                    queue.put((cache_key, scaled_image))
+                    return
             except Exception:
                 pass
 
@@ -488,15 +522,14 @@ class ImageCache:
         for fmt in formats:
             try:
                 image_url = urljoin(base_url, quote(f"{base_name}{fmt}", safe=""))
-                response = requests.get(image_url, timeout=5)
-                response.raise_for_status()
+                content = _fetch_image_bytes(_image_session, image_url)
+                if content is not None:
+                    image_data = BytesIO(content)
+                    image = pygame.image.load(image_data).convert_alpha()
+                    scaled_image = pygame.transform.smoothscale(image, target_size)
 
-                image_data = BytesIO(response.content)
-                image = pygame.image.load(image_data).convert_alpha()
-                scaled_image = pygame.transform.smoothscale(image, target_size)
-
-                queue.put((cache_key, scaled_image))
-                return
+                    queue.put((cache_key, scaled_image))
+                    return
 
             except Exception:
                 continue
@@ -517,27 +550,26 @@ class ImageCache:
         matched_url = self._resolve_thumbnail_url(base_url, base_name)
         if matched_url:
             try:
-                response = requests.get(matched_url, timeout=10)
-                response.raise_for_status()
+                content = _fetch_image_bytes(_image_session, matched_url)
+                if content is not None:
+                    image_data = BytesIO(content)
+                    image = pygame.image.load(image_data)
 
-                image_data = BytesIO(response.content)
-                image = pygame.image.load(image_data)
+                    original_size = image.get_size()
+                    max_dimension = max(original_size)
 
-                original_size = image.get_size()
-                max_dimension = max(original_size)
+                    if max_dimension > 800:
+                        scale_factor = 800 / max_dimension
+                        new_width = int(original_size[0] * scale_factor)
+                        new_height = int(original_size[1] * scale_factor)
+                        scaled_image = pygame.transform.smoothscale(
+                            image, (new_width, new_height)
+                        )
+                    else:
+                        scaled_image = image
 
-                if max_dimension > 800:
-                    scale_factor = 800 / max_dimension
-                    new_width = int(original_size[0] * scale_factor)
-                    new_height = int(original_size[1] * scale_factor)
-                    scaled_image = pygame.transform.smoothscale(
-                        image, (new_width, new_height)
-                    )
-                else:
-                    scaled_image = image
-
-                self._hires_queue.put((cache_key, scaled_image))
-                return
+                    self._hires_queue.put((cache_key, scaled_image))
+                    return
             except Exception:
                 pass
 
@@ -548,28 +580,27 @@ class ImageCache:
                     base_url if base_url.endswith("/") else base_url + "/",
                     quote(f"{base_name}{fmt}", safe=""),
                 )
-                response = requests.get(url, timeout=10)
-                response.raise_for_status()
+                content = _fetch_image_bytes(_image_session, url)
+                if content is not None:
+                    image_data = BytesIO(content)
+                    image = pygame.image.load(image_data)
 
-                image_data = BytesIO(response.content)
-                image = pygame.image.load(image_data)
+                    # Only scale down if extremely large
+                    original_size = image.get_size()
+                    max_dimension = max(original_size)
 
-                # Only scale down if extremely large
-                original_size = image.get_size()
-                max_dimension = max(original_size)
+                    if max_dimension > 800:
+                        scale_factor = 800 / max_dimension
+                        new_width = int(original_size[0] * scale_factor)
+                        new_height = int(original_size[1] * scale_factor)
+                        scaled_image = pygame.transform.smoothscale(
+                            image, (new_width, new_height)
+                        )
+                    else:
+                        scaled_image = image
 
-                if max_dimension > 800:
-                    scale_factor = 800 / max_dimension
-                    new_width = int(original_size[0] * scale_factor)
-                    new_height = int(original_size[1] * scale_factor)
-                    scaled_image = pygame.transform.smoothscale(
-                        image, (new_width, new_height)
-                    )
-                else:
-                    scaled_image = image
-
-                self._hires_queue.put((cache_key, scaled_image))
-                return
+                    self._hires_queue.put((cache_key, scaled_image))
+                    return
 
             except Exception:
                 continue

--- a/tests/test_image_cache_fetch.py
+++ b/tests/test_image_cache_fetch.py
@@ -1,0 +1,178 @@
+"""Tests for image_cache._fetch_image_bytes (GAB-11).
+
+The image fetch path needs robust retry/backoff behaviour so transient
+network problems (timeouts, dropped connections, 5xx) don't permanently fail
+a thumbnail/boxart load, while permanent failures (404/403/etc.) fail fast
+without wasting time on retries.
+
+These tests pin the contract of the (to-be-implemented) helper:
+
+    ic._fetch_image_bytes(session, url, *, connect=5, read=15, attempts=3) -> bytes | None
+
+    - returns resp.content on 2xx
+    - returns None WITHOUT retrying on permanent statuses {400,401,403,404,410}
+    - retries on Timeout / ConnectionError / 5xx with backoff sleeps, up to
+      `attempts` total, then returns None
+    - calls session.get(url, timeout=(connect, read))
+"""
+
+import importlib.util
+import os
+import sys
+
+# Headless: must be set BEFORE anything imports pygame.
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import requests  # noqa: E402  (for its exception classes)
+
+# Load the module directly from its file so we don't trigger
+# src/services/__init__.py (which chains into the nsz CLI and calls sys.exit).
+# Importing as a module object still lets us monkeypatch its globals.
+_spec = importlib.util.spec_from_file_location(
+    "image_cache",
+    os.path.join(os.path.dirname(__file__), "..", "src", "services", "image_cache.py"),
+)
+ic = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ic)
+
+
+class _FakeResp:
+    """Minimal stand-in for a requests.Response."""
+
+    def __init__(self, status_code, content=b""):
+        self.status_code = status_code
+        self.content = content
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(
+                f"{self.status_code} Error", response=self
+            )
+
+
+class _FakeSession:
+    """Fake session whose .get is driven by a list of scripted outcomes.
+
+    Each item in `outcomes` is either a _FakeResp to return or an Exception
+    instance to raise. If outcomes is exhausted, the last item repeats.
+    Records every (args, kwargs) it was called with.
+    """
+
+    def __init__(self, outcomes):
+        self._outcomes = list(outcomes)
+        self.calls = []
+
+    def get(self, url, timeout=None, **kwargs):
+        self.calls.append({"url": url, "timeout": timeout, "kwargs": kwargs})
+        idx = min(len(self.calls) - 1, len(self._outcomes) - 1)
+        outcome = self._outcomes[idx]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    @property
+    def call_count(self):
+        return len(self.calls)
+
+
+def _patch_sleep(monkeypatch):
+    """Replace time.sleep with a recorder so tests are instant.
+
+    Patching the `time` module's sleep covers both `import time; time.sleep`
+    and `ic.time.sleep` usage in the implementation.
+    """
+    recorded = []
+
+    def _fake_sleep(seconds):
+        recorded.append(seconds)
+
+    import time
+
+    monkeypatch.setattr(time, "sleep", _fake_sleep)
+    return recorded
+
+
+def test_success_returns_bytes(monkeypatch):
+    _patch_sleep(monkeypatch)
+    session = _FakeSession([_FakeResp(200, content=b"PNG")])
+
+    result = ic._fetch_image_bytes(session, "http://x/a.png")
+
+    assert result == b"PNG"
+    assert session.call_count == 1
+
+
+def test_404_fails_fast_no_retry(monkeypatch):
+    _patch_sleep(monkeypatch)
+    session = _FakeSession([_FakeResp(404)])
+
+    result = ic._fetch_image_bytes(session, "http://x/missing.png")
+
+    assert result is None
+    assert session.call_count == 1
+
+
+def test_403_fails_fast_no_retry(monkeypatch):
+    _patch_sleep(monkeypatch)
+    session = _FakeSession([_FakeResp(403)])
+
+    result = ic._fetch_image_bytes(session, "http://x/forbidden.png")
+
+    assert result is None
+    assert session.call_count == 1
+
+
+def test_timeout_retries_then_none(monkeypatch):
+    _patch_sleep(monkeypatch)
+    session = _FakeSession([requests.exceptions.Timeout("slow")])
+
+    result = ic._fetch_image_bytes(session, "http://x/a.png", attempts=3)
+
+    assert result is None
+    assert session.call_count == 3
+
+
+def test_timeout_then_success(monkeypatch):
+    _patch_sleep(monkeypatch)
+    session = _FakeSession(
+        [requests.exceptions.Timeout("slow"), _FakeResp(200, content=b"OK")]
+    )
+
+    result = ic._fetch_image_bytes(session, "http://x/a.png", attempts=3)
+
+    assert result == b"OK"
+    assert session.call_count == 2
+
+
+def test_5xx_retries_then_none(monkeypatch):
+    _patch_sleep(monkeypatch)
+    session = _FakeSession([_FakeResp(500)])
+
+    result = ic._fetch_image_bytes(session, "http://x/a.png", attempts=3)
+
+    assert result is None
+    assert session.call_count == 3
+
+
+def test_uses_tuple_timeout(monkeypatch):
+    _patch_sleep(monkeypatch)
+    session = _FakeSession([_FakeResp(200, content=b"PNG")])
+
+    ic._fetch_image_bytes(session, "http://x/a.png")
+
+    assert session.calls[0]["timeout"] == (5, 15)
+
+
+def test_backoff_sleeps_between_retries(monkeypatch):
+    recorded = _patch_sleep(monkeypatch)
+    session = _FakeSession([requests.exceptions.Timeout("slow")])
+
+    result = ic._fetch_image_bytes(session, "http://x/a.png", attempts=3)
+
+    assert result is None
+    # attempts - 1 sleeps: no sleep after the final failed attempt.
+    assert len(recorded) == 2
+    assert all(s > 0 for s in recorded)


### PR DESCRIPTION
Closes GAB-11.

## Problem
NS banner images load slowly and sometimes only appear after leaving and re-entering the system.

## Root cause
Commit `7541ce4` added retry + a 30s timeout to `_load_image_async` (direct banner URLs), but the **fallback** paths were left behind:
- `_load_image_with_fallback` — `timeout=5`, no retry
- `_load_hires_with_fallback` — `timeout=10`, no retry

NS banners that resolve via listing/fuzzy-match go through those paths and fail fast on weak handheld networks.

## Fix (minimal, cache-layer only)
- Add a shared pooled `requests.Session` (`HTTPAdapter` pool_maxsize=4), mirroring `download_manager`'s pattern.
- Add one reusable helper `_fetch_image_bytes(session, url, *, connect=5, read=15, attempts=3)`: `(5,15)` connect/read timeout, retry on `Timeout`/`ConnectionError`/5xx with `0.5s, 2.0s` backoff, **fail-fast (no retry) on permanent statuses** 400/401/403/404/410.
- Route both fallback paths through it. `_load_image_async` semantics unchanged; pygame load/scale/queue + None-fallthrough preserved.

## Tests (TDD)
`tests/test_image_cache_fetch.py` — 8 tests (success, fail-fast 404/403, timeout/5xx retry→None, timeout-then-success, `(5,15)` timeout, backoff schedule). **Full suite: 185 passed**, no regressions. QA: PASS-WITH-NOTES, no bugs found.

## Deferred / follow-up
Pre-warming visible thumbnails on screen entry (eliminates the first-frame placeholder window) — touches UI screen flow, intentionally out of this focused PR.

## ⚠️ On-device verification
The end-to-end "only after re-entering" symptom and real NS CDN behavior need confirmation on physical hardware (developed on a Linux VM).

---
Delivered by the `console-utils-squad` pipeline: Research → CTO → Architect → Tester (TDD) → Developer → QA → PR.