### PR TITLE
Fix GAB-12: clear "no game found" alert when scraper finds no match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ platforms
 system-images
 .superpowers
 docs/superpowers
+# Local dev virtualenv (squad pipeline)
+.venv/

--- a/src/app.py
+++ b/src/app.py
@@ -7999,14 +7999,16 @@ class ConsoleUtilitiesApp:
         def search():
             success, results, error = service.search_game(game_name, rom_path=rom_path)
 
-            if not success:
+            from services.scraper_outcome import classify_search_outcome
+
+            outcome = classify_search_outcome(success, results, error)
+            if outcome == "error":
                 wizard.step = "error"
                 wizard.error_message = error or "Search failed"
                 return
-
-            if not results:
+            if outcome == "no_match":
                 wizard.step = "error"
-                wizard.error_message = f"No results for: {game_name}"
+                wizard.error_message = f"No game found for: {game_name}"
                 return
 
             # Convert results to dict format for display

--- a/src/services/scraper_outcome.py
+++ b/src/services/scraper_outcome.py
@@ -1,0 +1,11 @@
+"""Pure helper for classifying scraper search outcomes (GAB-12)."""
+
+
+def classify_search_outcome(success, results, error=None):
+    """Return 'error' if the search failed, 'no_match' if it succeeded
+    with no results, else 'success'."""
+    if not success:
+        return "error"
+    if not results:
+        return "no_match"
+    return "success"

--- a/tests/test_scraper_outcome.py
+++ b/tests/test_scraper_outcome.py
@@ -1,0 +1,52 @@
+"""Tests for search outcome classification (GAB-12)."""
+
+import importlib.util
+import os
+
+# Be safe: ensure headless SDL before any pygame-touching import. The target
+# module is pure and should not import pygame, but set this defensively.
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+
+def _load():
+    """Load scraper_outcome directly by file path.
+
+    Avoids services/__init__.py (which pulls in heavy deps that crash under
+    pytest). The target module has no relative imports, so loading it by path
+    is clean. Loaded lazily inside each test so collection stays clean and
+    failures point at the missing module/function (the right reason).
+    """
+    mod_path = os.path.join(
+        os.path.dirname(__file__), "..", "src", "services", "scraper_outcome.py"
+    )
+    spec = importlib.util.spec_from_file_location("scraper_outcome", mod_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestClassifySearchOutcome:
+    def test_success_with_results(self):
+        mod = _load()
+        assert mod.classify_search_outcome(True, [object()], "") == "success"
+
+    def test_success_empty_results_is_no_match(self):
+        mod = _load()
+        assert mod.classify_search_outcome(True, [], "") == "no_match"
+
+    def test_failure_is_error(self):
+        mod = _load()
+        assert mod.classify_search_outcome(False, [], "boom") == "error"
+
+    def test_failure_with_empty_error_still_error(self):
+        mod = _load()
+        assert mod.classify_search_outcome(False, [], "") == "error"
+
+    def test_no_match_independent_of_error_text(self):
+        mod = _load()
+        assert mod.classify_search_outcome(True, [], "ignored") == "no_match"
+
+    def test_failure_takes_precedence_over_results(self):
+        mod = _load()
+        assert mod.classify_search_outcome(False, [object()], "x") == "error"


### PR DESCRIPTION
Closes GAB-12.

## Problem
When Screen Scraper found no match, the intent is to show a clear "no game found" alert rather than an empty game selector.

## Findings
On current `main` the **single-ROM** search already guards empty results (routes to the error step) and **batch** scraping auto-skips no-match (`scraper_manager.py`) — so an empty selector doesn't reproduce. The real gaps were an **ambiguous message** and **ad-hoc, duplicated** outcome handling.

## Fix (minimal, low-risk)
- New dependency-free pure module `src/services/scraper_outcome.py`: `classify_search_outcome(success, results, error) -> 'success' | 'no_match' | 'error'`.
- `_search_scraper_game` routes through it; the no-match case now shows a **distinct alert** — `"No game found for: <name>"` — via the existing error modal, while genuine failures keep their real error. Success path (→ `game_select`) unchanged, so the selector is never shown empty.

## Tests (TDD)
`tests/test_scraper_outcome.py` — 6 tests (success/no_match/error precedence + error-text independence). **Full suite: 183 passed.** QA: PASS, no bugs.

## ⚠️ On-device verification
The rendered alert wording/layout needs a quick visual check on real hardware.

---
Delivered by the `console-utils-squad` pipeline: Research → CTO → Architect → Tester (TDD) → Developer → QA → PR.