### PR TITLE
Fix GAB-13: open Android soft keyboard for Internet Archive wizards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ platforms
 system-images
 .superpowers
 docs/superpowers
+# Local dev virtualenv (squad pipeline)
+.venv/

--- a/src/app.py
+++ b/src/app.py
@@ -71,6 +71,7 @@ from input.navigation import NavigationHandler
 from input.controller import ControllerHandler
 from input.touch import TouchHandler
 from ui.theme import Theme
+from ui.keyboard_state import ia_wizard_needs_keyboard
 from ui.screens.screen_manager import ScreenManager
 from utils.logging import log_error, init_log_file
 
@@ -6450,6 +6451,13 @@ class ConsoleUtilitiesApp:
             or (
                 self.state.scraper_wizard.show
                 and self.state.scraper_wizard.step == "edit_name"
+            )
+            or ia_wizard_needs_keyboard(
+                self.state.ia_download_wizard.show,
+                self.state.ia_download_wizard.step,
+                self.state.ia_collection_wizard.show,
+                self.state.ia_collection_wizard.step,
+                self.state.ia_collection_wizard.adding_custom_format,
             )
         )
 

--- a/src/ui/keyboard_state.py
+++ b/src/ui/keyboard_state.py
@@ -1,0 +1,13 @@
+'''Pure keyboard-need predicates for IA wizards (no pygame, unit-testable). GAB-13.'''
+
+
+def ia_wizard_needs_keyboard(dl_show, dl_step, col_show, col_step, col_adding_custom):
+    """True iff an IA wizard is on a text-entry step needing the soft keyboard."""
+    if dl_show and dl_step == "url":
+        return True
+    if col_show and (
+        col_step in ("url", "name")
+        or (col_step == "formats" and col_adding_custom)
+    ):
+        return True
+    return False

--- a/tests/test_keyboard_state.py
+++ b/tests/test_keyboard_state.py
@@ -1,0 +1,59 @@
+"""Tests for the IA wizard keyboard-need predicate (GAB-13).
+
+`ia_wizard_needs_keyboard` is a pure function deciding whether the on-screen
+keyboard must be shown for the Internet Archive download / collection wizard,
+based on which wizard is visible and which step it is on.
+"""
+
+import os
+import sys
+
+# Defensive SDL dummy env (module is dependency-free, but keep parity with the
+# rest of the suite which may import pygame transitively).
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from ui.keyboard_state import ia_wizard_needs_keyboard
+
+
+def test_download_url_step_true():
+    assert ia_wizard_needs_keyboard(True, "url", False, "", False) is True
+
+
+def test_download_non_url_steps_false():
+    for step in ["validating", "file_select", "options", "downloading"]:
+        assert ia_wizard_needs_keyboard(True, step, False, "", False) is False
+
+
+def test_download_hidden_url_false():
+    assert ia_wizard_needs_keyboard(False, "url", False, "", False) is False
+
+
+def test_collection_url_true():
+    assert ia_wizard_needs_keyboard(False, "", True, "url", False) is True
+
+
+def test_collection_name_true():
+    assert ia_wizard_needs_keyboard(False, "", True, "name", False) is True
+
+
+def test_collection_formats_true_when_adding_custom():
+    assert ia_wizard_needs_keyboard(False, "", True, "formats", True) is True
+
+
+def test_collection_formats_false_without_custom():
+    assert ia_wizard_needs_keyboard(False, "", True, "formats", False) is False
+
+
+def test_collection_folder_false():
+    assert ia_wizard_needs_keyboard(False, "", True, "folder", False) is False
+
+
+def test_collection_hidden_false():
+    assert ia_wizard_needs_keyboard(False, "", False, "url", False) is False
+
+
+def test_both_hidden_false():
+    assert ia_wizard_needs_keyboard(False, "", False, "", False) is False


### PR DESCRIPTION
Closes GAB-13.

## Problem
On Android, selecting "download from internet archive" / "add internet archive collection" never opened the soft keyboard, so the URL/identifier couldn't be typed.

## Root cause
The Android soft keyboard is toggled by `pygame.key.start_text_input()` / `stop_text_input()` (app.py:931-939), gated by `_is_text_modal_open()` (app.py:6437-6454). That gate registered search/url/folder/login/auth/`scraper_wizard.edit_name` but **omitted `ia_download_wizard` and `ia_collection_wizard`** — so `start_text_input()` never fired for them.

## Fix (minimal)
- New dependency-free `src/ui/keyboard_state.py`: pure `ia_wizard_needs_keyboard(dl_show, dl_step, col_show, col_step, col_adding_custom)` — True for IA download `step=="url"`; IA collection `step in ("url","name")`; and `"formats"` only while `adding_custom_format` (the `"folder"` step uses the folder browser, no keyboard).
- Register it (step-aware) in `_is_text_modal_open()`.

`_is_text_modal_open()` is consulted **only** by the Android keyboard toggle (`BUILD_TARGET=="android"`), so desktop/web behavior is unchanged.

## Tests (TDD)
`tests/test_keyboard_state.py` — 10 tests across all step/visibility combinations. **Full suite: 187 passed.** QA: PASS, no bugs.

## ⚠️ On-device verification
Confirm the keyboard actually appears for these flows on real Android hardware.

---
Delivered by the `console-utils-squad` pipeline: Research → CTO → Architect → Tester (TDD) → Developer → QA → PR.