### PR TITLE
Fix GAB-14: implement file-utils "download from URL" confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ platforms
 system-images
 .superpowers
 docs/superpowers
+# Local dev virtualenv (squad pipeline)
+.venv/

--- a/src/app.py
+++ b/src/app.py
@@ -5875,6 +5875,8 @@ class ConsoleUtilitiesApp:
                     self.state.syncthing.custom_name_input = name
                     # Open folder browser to pick source folder
                     self._open_folder_browser("custom_save_source")
+            elif self.state.url_input.context == "direct_download":
+                self._submit_direct_download_url()
             else:
                 self.state.url_input.show = False
 
@@ -6003,7 +6005,50 @@ class ConsoleUtilitiesApp:
 
     def _submit_url_input(self):
         """Handle URL input submission from keyboard/Android."""
+        if self.state.url_input.context == "direct_download":
+            self._submit_direct_download_url()
+        else:
+            self.state.url_input.show = False
+
+    def _submit_direct_download_url(self):
+        """Validate and queue a direct http(s) download URL."""
+        from services.url_download import (
+            derive_download_filename,
+            is_valid_download_url,
+        )
+
+        url = self.state.url_input.input_text.strip()
+        if not is_valid_download_url(url):
+            self.state.url_input.error_message = "Enter a valid http(s) URL"
+            return
+
+        filename = derive_download_filename(url)
+
+        game = {
+            "name": filename,
+            "filename": filename,
+            "href": url,
+            "size": 0,
+        }
+        system_data = {
+            "name": "Direct Download",
+            "url": "",
+            "download_url": True,
+            "file_format": (
+                ["." + filename.rsplit(".", 1)[-1]] if "." in filename else [""]
+            ),
+            "roms_folder": "",
+            "should_unzip": False,
+        }
+
+        self.download_manager.add_to_queue([game], system_data, "Direct Download")
+
         self.state.url_input.show = False
+        self.state.url_input.error_message = ""
+        self.state.mode = "downloads"
+        self.state.download_queue.highlighted = max(
+            0, len(self.state.download_queue.items) - 1
+        )
 
     def _handle_text_modal_ok_click(self):
         """Handle OK button click on text input modals."""

--- a/src/services/url_download.py
+++ b/src/services/url_download.py
@@ -1,0 +1,28 @@
+"""Pure helpers for direct URL downloads (GAB-14).
+
+No pygame/service imports so this module is safe to load in isolation.
+"""
+
+import os
+import re
+from urllib.parse import urlparse
+
+
+def is_valid_download_url(url):
+    """Return True only for non-empty http(s) URLs with a network location."""
+    if not url or not url.strip():
+        return False
+    parse = urlparse(url.strip())
+    return parse.scheme in ("http", "https") and bool(parse.netloc)
+
+
+def derive_download_filename(url):
+    """Derive a safe filename from a URL, falling back to "download"."""
+    parse = urlparse(url.strip())
+    base = os.path.basename(parse.path)
+    # urlparse already separates query/fragment, but strip defensively.
+    base = base.split("?", 1)[0].split("#", 1)[0]
+    result = re.sub(r'[<>:"/\\|?*]', "_", base)
+    if not result or not result.strip("_ \t"):
+        return "download"
+    return result

--- a/src/state.py
+++ b/src/state.py
@@ -111,6 +111,7 @@ class UrlInputState:
     cursor_position: int = 0
     context: str = "archive_json"  # "archive_json" or "direct_download"
     shift_active: bool = False
+    error_message: str = ""
 
 
 @dataclass

--- a/tests/test_url_download.py
+++ b/tests/test_url_download.py
@@ -1,0 +1,89 @@
+"""Tests for URL download validation and filename derivation (GAB-14)."""
+
+import importlib.util
+import os
+
+# Defensive headless defaults so collection never tries to open a display.
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+# Load src/services/url_download.py DIRECTLY by file path to avoid
+# services/__init__.py (which pulls in heavy deps that crash under pytest).
+# A lazy loader keeps collection clean even before the module file exists:
+# importing happens at test-call time, not at collection time.
+_mod_path = os.path.join(
+    os.path.dirname(__file__), "..", "src", "services", "url_download.py"
+)
+
+_mod = None
+
+
+def _load():
+    global _mod
+    if _mod is None:
+        spec = importlib.util.spec_from_file_location("url_download", _mod_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        _mod = mod
+    return _mod
+
+
+class TestIsValidDownloadUrl:
+    def test_valid_http(self):
+        mod = _load()
+        assert mod.is_valid_download_url("http://example.com/f.zip") is True
+
+    def test_valid_https(self):
+        mod = _load()
+        assert mod.is_valid_download_url("https://example.com/f.zip") is True
+
+    def test_empty_false(self):
+        mod = _load()
+        assert mod.is_valid_download_url("") is False
+
+    def test_whitespace_false(self):
+        mod = _load()
+        assert mod.is_valid_download_url("   ") is False
+
+    def test_no_scheme_false(self):
+        mod = _load()
+        assert mod.is_valid_download_url("example.com/f.zip") is False
+
+    def test_ftp_rejected(self):
+        mod = _load()
+        assert mod.is_valid_download_url("ftp://example.com/f.zip") is False
+
+
+class TestDeriveDownloadFilename:
+    def test_normal(self):
+        mod = _load()
+        assert mod.derive_download_filename("https://x.com/path/game.zip") == "game.zip"
+
+    def test_trailing_slash(self):
+        mod = _load()
+        assert mod.derive_download_filename("https://x.com/path/") == "download"
+
+    def test_strips_query(self):
+        mod = _load()
+        assert mod.derive_download_filename("https://x.com/f.zip?token=abc") == "f.zip"
+
+    def test_strips_fragment(self):
+        mod = _load()
+        assert mod.derive_download_filename("https://x.com/f.zip#frag") == "f.zip"
+
+    def test_no_basename_fallback(self):
+        mod = _load()
+        assert mod.derive_download_filename("https://host") == "download"
+
+    def test_sanitizes_illegal(self):
+        # urlparse keeps ':' and '*' inside the path component, so a basename
+        # like 'a:b*c.zip' exercises the illegal-char sanitization. Chars from
+        # the set <>:"/\|?* must not survive in the result. ('/' would split
+        # the path and '?' starts the query, so we focus on the chars that can
+        # legitimately appear in a urlparse path: ':' and '*'.)
+        mod = _load()
+        result = mod.derive_download_filename("https://x.com/path/a:b*c.zip")
+        illegal = set('<>:"/\\|?*')
+        assert not (set(result) & illegal), f"illegal chars remain in {result!r}"
+        # The non-illegal characters should be preserved (replaced ones -> '_').
+        assert result == "a_b_c.zip"


### PR DESCRIPTION
Closes GAB-14.

## Problem
In file-utils "download from URL", after typing a URL, pressing **A** (Android) returned to the utilities screen instead of starting the download. The ticket notes it may also affect other platforms.

## Root cause (deeper than a key-mapping bug)
The `download_url` utility action opens the URL modal with `context="direct_download"` (app.py:4464), but **no confirm path ever started a download** for that context:
- Desktop on-screen-keyboard confirm (`_handle_url_input_selection`) handled only `syncthing_device_id` / `custom_save_name`; everything else fell through to `else: url_input.show = False`.
- Android OK → `_submit_url_input` only did `url_input.show = False`.

So confirming silently closed the modal on **every** platform — the submit was unimplemented.

## Fix
- New pure `src/services/url_download.py`: `is_valid_download_url()` (http/https + host) and `derive_download_filename()` (urlparse → basename, strip query/fragment, sanitize illegal chars, fallback `"download"`).
- `UrlInputState` gains `error_message`.
- New `_submit_direct_download_url()`: validates (invalid → keep modal open + set error), else builds a queue entry mirroring `_start_ia_download` (`href=url`, `download_url=True`) and calls `download_manager.add_to_queue([game], system_data, "Direct Download")`, then navigates to downloads.
- Wired into **both** the desktop `is_done` handler and the Android `_submit_url_input` dispatch for `direct_download`. Other contexts unchanged.

## Tests (TDD)
`tests/test_url_download.py` — 12 tests (URL validation + filename derivation/sanitization/fallback). **Full suite: 189 passed.** QA: PASS — verified the `add_to_queue` dict shapes match and both confirm paths reach the new handler (no crash/KeyError risk).

## Follow-up / on-device
- `error_message` is set but not yet rendered in the URL modal (field added; renderer untouched here).
- Confirm on real Android hardware that A now starts the download.

---
Delivered by the `console-utils-squad` pipeline: Research → CTO → Architect → Tester (TDD) → Developer → QA → PR.