### PR TITLE
Fix GAB-16: case-insensitive region priority + dedup tests (low-end perf)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ platforms
 system-images
 .superpowers
 docs/superpowers
+# Local dev virtualenv (squad pipeline)
+.venv/

--- a/src/services/file_listing.py
+++ b/src/services/file_listing.py
@@ -80,15 +80,15 @@ def _dedupe_game_list(files: List[Any]) -> List[Any]:
 
     # Pick best from each group - O(n) since we iterate groups once
     def _priority(f):
-        name = _get_filename(f)
+        name = _get_filename(f).lower()
         # Lower score = higher priority
-        if "(USA)" in name:
+        if "(usa)" in name:
             region = 0
-        elif "(World)" in name:
+        elif "(world)" in name:
             region = 1
-        elif "(USA, Europe)" in name or "(Europe, USA)" in name:
+        elif "(usa, europe)" in name or "(europe, usa)" in name:
             region = 2
-        elif "(Europe)" in name:
+        elif "(europe)" in name:
             region = 3
         else:
             region = 4

--- a/tests/test_dedupe_game_list.py
+++ b/tests/test_dedupe_game_list.py
@@ -1,0 +1,118 @@
+"""Tests for _dedupe_game_list in src/services/file_listing.py (GAB-16)."""
+
+import importlib.util
+import os
+import sys
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+_src = os.path.join(os.path.dirname(__file__), "..", "src")
+sys.path.insert(0, _src)
+_mp = os.path.join(_src, "services", "file_listing.py")
+_spec = importlib.util.spec_from_file_location("file_listing", _mp)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+dedupe = _mod._dedupe_game_list
+
+
+def _chosen(result):
+    """Extract the single chosen filename from a result list."""
+    assert len(result) == 1
+    f = result[0]
+    return f.get("filename", "") if isinstance(f, dict) else str(f)
+
+
+def _filenames(result):
+    out = []
+    for f in result:
+        out.append(f.get("filename", "") if isinstance(f, dict) else str(f))
+    return out
+
+
+def test_merges_same_normalized_name():
+    files = [
+        {"filename": "Cool Game (USA).zip", "size": 10},
+        {"filename": "Cool Game (Europe).zip", "size": 10},
+    ]
+    result = dedupe(files)
+    assert len(result) == 1
+
+
+def test_usa_beats_europe():
+    files = [
+        {"filename": "Cool Game (USA).zip", "size": 10},
+        {"filename": "Cool Game (Europe).zip", "size": 10},
+    ]
+    result = dedupe(files)
+    assert "(USA)" in _chosen(result)
+
+
+def test_mixed_case_usa_beats_europe():
+    # RED test: on current case-sensitive code, "(usa)" falls to region 4,
+    # so the larger Europe entry wins. Passes after case-insensitive fix.
+    files = [
+        {"filename": "Cool Game (usa).zip", "size": 10},
+        {"filename": "Cool Game (Europe).zip", "size": 20},
+    ]
+    result = dedupe(files)
+    assert _chosen(result) == "Cool Game (usa).zip"
+
+
+def test_size_tiebreak():
+    files = [
+        {"filename": "Cool Game (USA).zip", "size": 5},
+        {"filename": "Cool Game (USA) (Rev 1).zip", "size": 50},
+    ]
+    result = dedupe(files)
+    assert result[0].get("size") == 50
+
+
+def test_world_beats_europe():
+    files = [
+        {"filename": "Cool Game (World).zip", "size": 10},
+        {"filename": "Cool Game (Europe).zip", "size": 10},
+    ]
+    result = dedupe(files)
+    assert "(World)" in _chosen(result)
+
+
+def test_usa_europe_combo_ranking():
+    # (USA, Europe) beats (Europe)
+    files = [
+        {"filename": "Cool Game (USA, Europe).zip", "size": 10},
+        {"filename": "Cool Game (Europe).zip", "size": 10},
+    ]
+    result = dedupe(files)
+    assert "(USA, Europe)" in _chosen(result)
+
+    # (USA) beats (USA, Europe)
+    files2 = [
+        {"filename": "Other Game (USA).zip", "size": 10},
+        {"filename": "Other Game (USA, Europe).zip", "size": 10},
+    ]
+    result2 = dedupe(files2)
+    assert _chosen(result2) == "Other Game (USA).zip"
+
+
+def test_malformed_entries_no_crash():
+    files = [
+        "barestring",
+        {"filename": "X (USA).zip"},
+        {"size": 5},
+    ]
+    result = dedupe(files)
+    assert isinstance(result, list)
+
+
+def test_empty_list():
+    assert dedupe([]) == []
+
+
+def test_distinct_games_preserved():
+    files = [
+        {"filename": "Game One (USA).zip", "size": 10},
+        {"filename": "Game Two (USA).zip", "size": 10},
+    ]
+    result = dedupe(files)
+    assert len(result) == 2


### PR DESCRIPTION
Relates to GAB-16.

## Context
The reported low-end slowness on multi-source backup lists was caused by the list-merge and was **already fixed on `main`** (commit `6621c61`: O(n) hash-grouped dedup + a `low_end_device_mode` that skips dedup). This PR hardens that work: it adds the **missing test coverage** and fixes a **latent correctness bug** found while reviewing the merge.

## Bug
`_dedupe_game_list` groups games by a **lowercased** normalized name, but the nested `_priority()` matched region tags **case-sensitively** (`"(USA)"`, `"(Europe)"`, …). So a `"(usa)"`-tagged entry fell into the catch-all region and could lose to a lower-priority `"(Europe)"` entry.

## Fix
Lowercase the filename once in `_priority()` and compare against lowercased tags. Region preference is now consistent with the grouping. **Grouping, O(n) complexity, size tiebreak, and output shape are unchanged** — correctly-cased inputs produce identical results.

## Tests (TDD)
`tests/test_dedupe_game_list.py` — 9 tests: dedup-by-normalized-name, USA>Europe, **mixed-case** USA>Europe (the red→green signal), size tiebreak, World>Europe, USA/USA-Europe ranking, malformed-input safety, empty list, distinct-game preservation. **Full suite: 186 passed.** QA: PASS, no bugs.

## Note
The core perf optimization itself was the prior merged commit; this PR locks its correctness with tests and fixes the casing edge case. On-device navigation speed is unchanged-or-better.

---
Delivered by the `console-utils-squad` pipeline: Research → CTO → Architect → Tester (TDD) → Developer → QA → PR.