### PR TITLE
Fix GAB-17: reset folder-browser state on gamepad Cancel (blank screen)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ platforms
 system-images
 .superpowers
 docs/superpowers
+# Local dev virtualenv (squad pipeline)
+.venv/

--- a/src/app.py
+++ b/src/app.py
@@ -6123,15 +6123,25 @@ class ConsoleUtilitiesApp:
             self.state.game_details.current_game = None
             self._start_download()
 
+    def _reset_folder_browser_state(self):
+        """Reset folder browser to a clean state (prevents blank screen on reopen)."""
+        fb = self.state.folder_browser
+        fb.show = False
+        fb.focus_area = "list"
+        fb.current_path = self.settings.get("work_dir", "")
+        fb.items = []
+        fb.highlighted = 0
+        fb.scroll_offset = 0
+        fb.button_index = 0
+
     def _handle_folder_browser_button_selection(self):
         """Handle folder browser button selection (Select/Cancel)."""
         if self.state.folder_browser.button_index == 0:
             # Select button - confirm current folder
             self._handle_folder_browser_confirm()
         else:
-            # Cancel button - close modal
-            self.state.folder_browser.show = False
-            self.state.folder_browser.focus_area = "list"
+            # Cancel button - close modal and reset state (GAB-17)
+            ConsoleUtilitiesApp._reset_folder_browser_state(self)
 
     def _handle_search_action(self):
         """Handle search key press."""

--- a/tests/test_folder_browser_navigation.py
+++ b/tests/test_folder_browser_navigation.py
@@ -144,3 +144,47 @@ def test_render_and_navigation_agree_on_folder_selection():
         assert is_folder_selection_type(st), f"{st} should be a folder selection"
     for st in FILE_SELECTION_TYPES:
         assert not is_folder_selection_type(st), f"{st} should be a file selection"
+
+
+def _fb_stub(button_index=1):
+    fb = FolderBrowserState()
+    fb.show = True
+    fb.items = [{"name": "x", "type": "folder"}]
+    fb.current_path = "/x"
+    fb.highlighted = 5
+    fb.scroll_offset = 10
+    fb.focus_area = "buttons"
+    fb.button_index = button_index
+    return SimpleNamespace(
+        state=SimpleNamespace(folder_browser=fb), settings={"work_dir": "/work"}
+    )
+
+
+def test_reset_folder_browser_state_clears_fields():
+    """GAB-17: resetting the folder browser clears all transient nav state."""
+    from app import ConsoleUtilitiesApp
+
+    stub = _fb_stub()
+    ConsoleUtilitiesApp._reset_folder_browser_state(stub)
+
+    fb = stub.state.folder_browser
+    assert fb.show is False
+    assert fb.focus_area == "list"
+    assert fb.current_path == "/work"
+    assert fb.items == []
+    assert fb.highlighted == 0
+    assert fb.scroll_offset == 0
+    assert fb.button_index == 0
+
+
+def test_button_cancel_resets_state():
+    """GAB-17: choosing Cancel must reset the browser, not just hide it."""
+    from app import ConsoleUtilitiesApp
+
+    s = _fb_stub(button_index=1)
+    ConsoleUtilitiesApp._handle_folder_browser_button_selection(s)
+
+    fb = s.state.folder_browser
+    assert fb.items == []
+    assert fb.current_path == "/work"
+    assert fb.show is False


### PR DESCRIPTION
Relates to GAB-17.

## Context
The blank-screen-on-cancel was largely fixed by `caf4d16`, which reset the folder-browser state on the **touch** handler (`_handle_click`) and the **back-button** handler (`_go_back`). This PR closes the remaining gap and adds the missing test coverage.

## Remaining bug
The **gamepad "Cancel button"** path — `_handle_folder_browser_button_selection` (app.py:6132-6134) — was missed: it only set `show=False`/`focus_area`, leaving stale `current_path` and `items`, which could still produce a blank screen on the next open.

## Fix
- Extract `_reset_folder_browser_state()` resetting `show`, `focus_area`, `current_path` (→ `work_dir`), `items`, `highlighted`, `scroll_offset`, `button_index` for a fully clean reopen.
- Call it from the Cancel branch. `_go_back` / `_handle_click` are left untouched (their IA-collection / scraper / steam follow-ups are preserved; the helper's first five fields already match what they set).

## Tests (TDD)
Two new tests in `tests/test_folder_browser_navigation.py` (reusing the file's stub-based pattern): one asserts the reset helper clears all 7 fields; one asserts the gamepad Cancel path resets state. `test_button_cancel_resets_state` was the red→green signal. **Full suite: 179 passed.** QA: PASS-WITH-NOTES (no bugs).

## Note
The Cancel branch calls `ConsoleUtilitiesApp._reset_folder_browser_state(self)` (explicit form) to remain compatible with the repo's existing `SimpleNamespace`-stub test convention; behavior is identical to `self._reset_folder_browser_state()` in production.

---
Delivered by the `console-utils-squad` pipeline: Research → CTO → Architect → Tester (TDD) → Developer → QA → PR.