### PR TITLE
GAB-18: scraper fallback orchestration (phase 1) + refactor design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ platforms
 system-images
 .superpowers
 docs/superpowers
+# Local dev virtualenv (squad pipeline)
+.venv/

--- a/docs/scraper-refactor-design.md
+++ b/docs/scraper-refactor-design.md
@@ -1,0 +1,81 @@
+# Scraper Refactor Design (GAB-18)
+
+Design notes for centralizing multi-provider scraper orchestration and
+charting the path toward platform-expansion fallback and a handheld-
+friendly scraping UX.
+
+## Competitor review
+
+Existing ROM scrapers converge on a few well-proven patterns:
+
+- **Skyscraper** chains lookups by descending confidence: file **hash**
+  match first (CRC/MD5/SHA1), then **exact filename** match, then a
+  **fuzzy** title match. It aggressively **caches** every resolved game
+  locally so re-runs and quota-limited sources are not hammered.
+- **ES-DE / Universal XML Scraper** are **hash-first** as well, then fall
+  back through title matching with **region fallback** (e.g. try the
+  user's region, then World/USA/EU/JP) so the right box art is chosen.
+- **ScreenScraper** is the de-facto **primary** source for most setups
+  because of its rich media set and hash database; tools treat it as the
+  first provider when credentials exist.
+- **TheGamesDB / ScreenScraper quotas**: both impose per-user request
+  budgets (ScreenScraper scales by contributor level; TheGamesDB by API
+  key tier). Tools mitigate this by caching and by only falling back to a
+  secondary source when the primary fails or is exhausted.
+
+Takeaway: confidence-ordered chaining, region/platform fallback, and
+caching to respect quotas are the shared backbone.
+
+## Recommended fallback + platform-expansion algorithm
+
+1. **Order configured providers.** Primary first, then the remaining
+   chain de-duplicated, keeping only providers that are actually
+   configured (`is_configured()`), swallowing construction errors. This
+   is now the pure `ordered_configured_providers` helper.
+2. **Same-platform first.** Search the ROM's own platform across all
+   configured providers. Return the first confident hit.
+3. **Then expand.** If no provider matches on the native platform, retry
+   the same providers against related platform ids (e.g. a multi-system
+   compilation, or libretro/ScreenScraper id mismatches). This is the
+   `search_same_platform_then_expand` helper.
+4. **Stop at first confident hit.** As soon as any `(provider, platform)`
+   pair returns results, accept it and stop searching.
+5. **Region fallback.** Within a provider, prefer the user's region for
+   media/title, then fall through World/USA/EU/JP (Phase 2+ concern,
+   handled inside individual providers).
+6. **Cache to respect quotas.** Auth/credential/api-key/quota errors do
+   **not** count as a "no match"; the provider is skipped so a healthy
+   secondary still answers. Resolved results should be cached so repeat
+   scrapes and quota-limited providers are not re-queried.
+
+## Recommended handheld UX
+
+Constrained to an 800x600 screen with D-pad/controller input.
+
+- **Single scrape**: show the candidate **title + box art + confidence**
+  score, with **Accept / Skip / Edit** actions. On a **no-match**, drop
+  straight into **edit-name** (on-screen keyboard) so the user can refine
+  the search term and retry without leaving the screen.
+- **Batch scrape**: show **progress N/M**, **auto-accept** high-confidence
+  matches without prompting, and **queue only ambiguous** ones for review.
+  Support **halt-to-current** (stop but keep everything matched so far)
+  and present a **final summary** (matched / skipped / failed counts).
+
+## Phased plan
+
+- **Phase 1 (THIS PR)** — Introduce the pure `scraper_orchestration`
+  module (`ordered_configured_providers`,
+  `search_game_with_fallback`, `search_same_platform_then_expand`) with
+  full unit tests, and delegate `ScraperService._get_provider_chain()`'s
+  multi-provider branch to `ordered_configured_providers`. Centralizes
+  true configured-provider fallback in dependency-free, testable code.
+  Backward compatible: the produced provider list is identical to before
+  for current configs, and the fallback-disabled branch is unchanged.
+- **Phase 2** — Wire `search_same_platform_then_expand` into
+  `ScraperService.search_game`, passing a `name_adapter` that carries the
+  existing libretro special-case name handling, plus an
+  `other_system_ids` source for platform expansion. Add caching and
+  region fallback inside providers.
+- **Phase 3** — UI overhaul: implement the single and batch scraping
+  screens described above (confidence display, Accept/Skip/Edit,
+  auto-accept, review queue, halt-to-current, final summary).

--- a/src/services/scraper_orchestration.py
+++ b/src/services/scraper_orchestration.py
@@ -1,0 +1,112 @@
+"""Pure scraper orchestration helpers (GAB-18).
+
+Dependency-free coordination logic for multi-provider scraping. This
+module deliberately imports only from ``typing`` so it can be unit
+tested in isolation, without pygame, network access, or provider side
+effects. Provider construction is injected via ``provider_factory`` and
+providers are treated as duck-typed objects exposing ``is_configured()``
+and ``search_game(name, system_id)``.
+"""
+
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+
+def ordered_configured_providers(
+    primary_name: str,
+    fallback_enabled: bool,
+    provider_chain: Sequence[str],
+    settings: Dict[str, Any],
+    provider_factory: Callable[[str, Dict[str, Any]], Any],
+) -> List[Tuple[str, Any]]:
+    """Build the ordered list of configured providers to try.
+
+    The primary provider is always first. When ``fallback_enabled`` is
+    truthy, the remaining names in ``provider_chain`` are appended (de-
+    duplicated, preserving order). Each name is instantiated via
+    ``provider_factory`` and kept only if ``is_configured()`` is truthy.
+    Any exception during construction or configuration check causes that
+    provider to be skipped.
+
+    Returns a list of ``(name, provider)`` tuples.
+    """
+    order = [primary_name]
+    if fallback_enabled:
+        for name in provider_chain:
+            if name not in order:
+                order.append(name)
+
+    result: List[Tuple[str, Any]] = []
+    for name in order:
+        try:
+            provider = provider_factory(name, settings)
+        except Exception:
+            continue
+        try:
+            if provider.is_configured():
+                result.append((name, provider))
+        except Exception:
+            continue
+    return result
+
+
+def search_game_with_fallback(
+    game_name: str,
+    system_id: str,
+    providers: Sequence[Tuple[str, Any]],
+    name_adapter: Optional[Callable[[str, str], str]] = None,
+) -> Tuple[bool, Optional[Any], str, Optional[str]]:
+    """Search providers in order, returning the first confident hit.
+
+    Auth/credential/quota style errors cause the provider to be skipped
+    without being treated as the surfaced error. Other errors are tracked
+    as ``last_error``. ``name_adapter(game_name, provider_name)`` lets a
+    caller adjust the search term per provider.
+
+    Returns ``(success, result, error, provider_name)``.
+    """
+    last_error = ""
+    for name, provider in providers:
+        search_name = name_adapter(game_name, name) if name_adapter else game_name
+        try:
+            ok, results, error = provider.search_game(search_name, system_id)
+        except Exception as e:
+            last_error = str(e)
+            continue
+        if ok and results:
+            return (True, results[0], "", name)
+        if error and any(
+            tok in error.lower()
+            for tok in ("auth", "credential", "api key", "quota")
+        ):
+            continue
+        if error:
+            last_error = error
+    return (False, None, last_error or "No results from any provider", None)
+
+
+def search_same_platform_then_expand(
+    game_name: str,
+    primary_system_id: str,
+    providers: Sequence[Tuple[str, Any]],
+    other_system_ids: Sequence[str] = (),
+    name_adapter: Optional[Callable[[str, str], str]] = None,
+) -> Tuple[bool, Optional[Any], str, Optional[str]]:
+    """Search the primary platform first, then expand to other platforms.
+
+    Phase 1 searches ``primary_system_id`` across all providers. If that
+    yields a hit it is returned immediately. Otherwise each id in
+    ``other_system_ids`` is searched in turn, returning the first hit. If
+    nothing matches anywhere, the phase 1 (negative) result is returned.
+
+    Returns ``(success, result, error, provider_name)``.
+    """
+    phase1 = search_game_with_fallback(
+        game_name, primary_system_id, providers, name_adapter
+    )
+    if phase1[0]:
+        return phase1
+    for sid in other_system_ids:
+        r = search_game_with_fallback(game_name, sid, providers, name_adapter)
+        if r[0]:
+            return r
+    return phase1

--- a/src/services/scraper_service.py
+++ b/src/services/scraper_service.py
@@ -166,22 +166,14 @@ class ScraperService:
         if not fallback:
             return [(primary, self.provider)]
 
-        # Build ordered list: primary first, then rest
-        ordered = [primary]
-        for p in self.PROVIDER_CHAIN:
-            if p not in ordered:
-                ordered.append(p)
+        # Multi-provider fallback: delegate to the pure orchestration
+        # helper. Produces the same list as before (primary first, chain
+        # minus dups, is_configured() filter, exceptions swallowed).
+        from .scraper_orchestration import ordered_configured_providers
 
-        providers = []
-        for name in ordered:
-            try:
-                p = get_provider(name, self.settings)
-                if p.is_configured():
-                    providers.append((name, p))
-            except (ValueError, Exception):
-                continue
-
-        return providers
+        return ordered_configured_providers(
+            primary, True, self.PROVIDER_CHAIN, self.settings, get_provider
+        )
 
     def extract_game_name(self, rom_path: str) -> str:
         """

--- a/tests/test_scraper_orchestration.py
+++ b/tests/test_scraper_orchestration.py
@@ -1,0 +1,218 @@
+"""Tests for scraper orchestration (GAB-18).
+
+The module under test is dependency-free (typing only), imported by file
+path to avoid services/__init__.py side effects. A lazy loader keeps test
+collection clean before the module file exists.
+"""
+
+import importlib.util
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+_mod_path = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "src",
+    "services",
+    "scraper_orchestration.py",
+)
+
+
+def _load():
+    """Lazily import the module by file path inside each test."""
+    spec = importlib.util.spec_from_file_location(
+        "scraper_orchestration", _mod_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class FakeProvider:
+    def __init__(self, configured=True, results=None, error="", record=None):
+        self._configured = configured
+        self._results = results
+        self._error = error
+        self._record = record
+
+    def is_configured(self):
+        return self._configured
+
+    def search_game(self, name, system_id=""):
+        if self._record is not None:
+            self._record.append((name, system_id))
+        return (bool(self._results), self._results or [], self._error)
+
+
+def make_factory(mapping):
+    """mapping: name -> provider. The name "boom" raises."""
+
+    def factory(name, settings):
+        if name == "boom":
+            raise RuntimeError("x")
+        return mapping[name]
+
+    return factory
+
+
+# --- ordered_configured_providers ---------------------------------------
+
+
+def test_ordering_primary_first():
+    mod = _load()
+    mapping = {
+        "a": FakeProvider(),
+        "b": FakeProvider(),
+        "c": FakeProvider(),
+    }
+    out = mod.ordered_configured_providers(
+        "a", True, ["b", "c"], {}, make_factory(mapping)
+    )
+    assert [name for name, _ in out] == ["a", "b", "c"]
+
+
+def test_fallback_disabled_primary_only():
+    mod = _load()
+    mapping = {"a": FakeProvider(), "b": FakeProvider()}
+    out = mod.ordered_configured_providers(
+        "a", False, ["b", "c"], {}, make_factory(mapping)
+    )
+    assert [name for name, _ in out] == ["a"]
+
+
+def test_unconfigured_filtered_out():
+    mod = _load()
+    mapping = {
+        "a": FakeProvider(configured=True),
+        "b": FakeProvider(configured=False),
+        "c": FakeProvider(configured=True),
+    }
+    out = mod.ordered_configured_providers(
+        "a", True, ["b", "c"], {}, make_factory(mapping)
+    )
+    assert [name for name, _ in out] == ["a", "c"]
+
+
+def test_factory_exception_skipped():
+    mod = _load()
+    mapping = {"a": FakeProvider(), "c": FakeProvider()}
+    out = mod.ordered_configured_providers(
+        "a", True, ["boom", "c"], {}, make_factory(mapping)
+    )
+    assert [name for name, _ in out] == ["a", "c"]
+
+
+def test_dedup_primary_in_chain():
+    mod = _load()
+    mapping = {"a": FakeProvider(), "b": FakeProvider()}
+    out = mod.ordered_configured_providers(
+        "a", True, ["a", "b"], {}, make_factory(mapping)
+    )
+    assert [name for name, _ in out] == ["a", "b"]
+
+
+# --- search_game_with_fallback -------------------------------------------
+
+
+def test_search_returns_first_non_empty():
+    mod = _load()
+    p = FakeProvider(results=["hit"])
+    success, result, error, name = mod.search_game_with_fallback(
+        "game", "sys", [("a", p)]
+    )
+    assert success is True
+    assert result == "hit"
+    assert error == ""
+    assert name == "a"
+
+
+def test_auth_error_skips_and_continues():
+    mod = _load()
+    bad = FakeProvider(error="API key invalid")
+    good = FakeProvider(results=["hit"])
+    success, result, error, name = mod.search_game_with_fallback(
+        "game", "sys", [("a", bad), ("b", good)]
+    )
+    assert success is True
+    assert result == "hit"
+    assert name == "b"
+
+
+def test_all_empty_returns_false():
+    mod = _load()
+    p1 = FakeProvider(results=[])
+    p2 = FakeProvider(results=[])
+    success, result, error, name = mod.search_game_with_fallback(
+        "game", "sys", [("a", p1), ("b", p2)]
+    )
+    assert success is False
+    assert result is None
+    assert isinstance(error, str) and error
+    assert name is None
+
+
+def test_non_auth_error_tracked_as_last_error():
+    mod = _load()
+    p = FakeProvider(results=[], error="network down")
+    success, result, error, name = mod.search_game_with_fallback(
+        "game", "sys", [("a", p)]
+    )
+    assert success is False
+    assert "network down" in error
+    assert name is None
+
+
+def test_name_adapter_applied():
+    mod = _load()
+    record = []
+    p = FakeProvider(results=["hit"], record=record)
+    mod.search_game_with_fallback(
+        "game", "sys", [("a", p)], name_adapter=lambda n, prov: n.upper()
+    )
+    assert record == [("GAME", "sys")]
+
+
+# --- search_same_platform_then_expand ------------------------------------
+
+
+def test_same_platform_hit_on_primary():
+    mod = _load()
+    record = []
+    p = FakeProvider(results=["hit"], record=record)
+    success, result, error, name = mod.search_same_platform_then_expand(
+        "game", "primary", [("a", p)], other_system_ids=["x", "y"]
+    )
+    assert success is True
+    assert record == [("game", "primary")]
+
+
+def test_expands_to_other_platform_when_primary_empty():
+    mod = _load()
+
+    class SnesOnly:
+        def is_configured(self):
+            return True
+
+        def search_game(self, name, system_id=""):
+            if system_id == "snes":
+                return (True, ["hit"], "")
+            return (False, [], "")
+
+    p = SnesOnly()
+    success, result, error, name = mod.search_same_platform_then_expand(
+        "game", "primary", [("a", p)], other_system_ids=["snes"]
+    )
+    assert success is True
+    assert result == "hit"
+
+
+def test_expand_returns_provider_name():
+    mod = _load()
+    p = FakeProvider(results=["hit"])
+    success, result, error, name = mod.search_same_platform_then_expand(
+        "game", "primary", [("zebra", p)], other_system_ids=["x"]
+    )
+    assert success is True
+    assert name == "zebra"


### PR DESCRIPTION
Relates to GAB-18 (phase 1 of a phased refactor).

## Why phased
GAB-18 is a large refactor (UX overhaul for single + batch, true multi-provider fallback, same-platform-first-then-expand) and explicitly asks to **review other apps before implementing the UI**. This PR delivers the **safe, testable core** + the **design** for the rest, rather than a risky big-bang rewrite.

## What's in this PR
- **New pure `src/services/scraper_orchestration.py`** (typing-only, no pygame/network/provider imports — fully unit-testable):
  - `ordered_configured_providers()` — primary-first, de-duped, `is_configured()`-filtered, factory-exception safe.
  - `search_game_with_fallback()` — tries providers in order, returns first non-empty match, skips auth/credential/api-key/quota errors (true fallback).
  - `search_same_platform_then_expand()` — same platform first, then expand to other platforms. **Shipped tested-but-dormant**; wiring is Phase 2.
- **`ScraperService._get_provider_chain()`** refactored to delegate its multi-provider path to `ordered_configured_providers` — **output identical** to before. The fallback-disabled branch (which relies on the cached `self.provider`) is left **byte-for-byte unchanged**. `search_game()` and all other methods untouched.
- **`docs/scraper-refactor-design.md`** — competitor review (Skyscraper hash→filename→fuzzy chaining, ES-DE/Universal XML Scraper region fallback, ScreenScraper primacy, TheGamesDB/ScreenScraper quotas), the recommended fallback + platform-expansion algorithm, recommended handheld UX for single & batch, and a phased plan.

## Tests (TDD)
`tests/test_scraper_orchestration.py` — 13 tests with fake providers (ordering, fallback-disabled, unconfigured-filtered, factory-exception, dedup, first-non-empty, auth-error skip, all-empty, last-error, name-adapter, same-platform-hit, expand-to-other-platform, provider-name). **Full suite: 190 passed.** QA: PASS — `_get_provider_chain` backward-compat verified; expansion confirmed dormant/not-wired.

## Phased plan
- **Phase 1 (this PR):** pure orchestration + tests + `_get_provider_chain` delegation + design doc.
- **Phase 2:** wire `search_same_platform_then_expand` into `search_game` (with a `name_adapter` carrying the libretro special-case) + an `other_system_ids` source.
- **Phase 3:** UI overhaul (single/batch UX per the design doc).

---
Delivered by the `console-utils-squad` pipeline: Research → CTO → Architect → Tester (TDD) → Developer → QA → PR.