### PR TITLE
Add GAB-19: auto-download scraped images after game download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ platforms
 system-images
 .superpowers
 docs/superpowers
+# Local dev virtualenv (squad pipeline)
+.venv/

--- a/src/app.py
+++ b/src/app.py
@@ -66,6 +66,7 @@ from services.image_cache import ImageCache
 from services.download_manager import DownloadManager as _DesktopDownloadManager
 from services.scraper_manager import ScraperManager
 from services.syncthing_service import SyncthingService
+from services.auto_scrape import should_auto_scrape, new_completions
 from services import file_explorer_service
 from input.navigation import NavigationHandler
 from input.controller import ControllerHandler
@@ -212,6 +213,9 @@ class ConsoleUtilitiesApp:
 
         # Initialize scraper manager
         self.scraper_manager = ScraperManager(self.settings, self.state.scraper_queue)
+
+        # Tracks last-seen download status per queue item (auto-scrape trigger)
+        self._dl_status_seen = {}
 
         # Initialize Syncthing service (lazily when needed)
         self.syncthing_service = None
@@ -927,6 +931,24 @@ class ConsoleUtilitiesApp:
                         self._show_ia_login_required_modal()
                         _dirty = True
                         break
+
+            # Auto-scrape newly completed downloads (opt-in, default OFF)
+            items = self.state.download_queue.items
+            completed_ids = new_completions(
+                self._dl_status_seen,
+                items,
+                id,
+                lambda it: getattr(it, "status", ""),
+            )
+            if completed_ids and should_auto_scrape(self.settings):
+                by_id = {id(it): it for it in items}
+                for cid in completed_ids:
+                    it = by_id.get(cid)
+                    if it is not None:
+                        self._trigger_auto_scrape(it)
+            self._dl_status_seen = {
+                id(it): getattr(it, "status", "") for it in items
+            }
 
             # Manage Android soft keyboard show/hide
             if BUILD_TARGET == "android":
@@ -4044,6 +4066,11 @@ class ConsoleUtilitiesApp:
             current = self.settings.get("scraper_frontend", "emulationstation_base")
             idx = frontends.index(current) if current in frontends else 0
             self.settings["scraper_frontend"] = frontends[(idx + 1) % len(frontends)]
+            save_settings(self.settings)
+        elif action == "toggle_auto_scrape_after_download":
+            self.settings["auto_scrape_after_download"] = not self.settings.get(
+                "auto_scrape_after_download", False
+            )
             save_settings(self.settings)
         elif action == "ia_login":
             self._show_ia_login()
@@ -8220,6 +8247,29 @@ class ConsoleUtilitiesApp:
         self._close_scraper_wizard()
         self.state.mode = "scraper_downloads"
         self.state.scraper_queue.highlighted = 0
+
+    def _trigger_auto_scrape(self, item):
+        """Auto-scrape a single completed download item (best-effort, opt-in)."""
+        try:
+            filename = self.download_manager._get_filename(item.game)
+            folder = self.download_manager._get_roms_folder(item.system_data)
+            rom_path = os.path.join(folder, filename)
+            roms = [{"name": filename, "path": rom_path}]
+            system = (
+                item.system_data.get("name", "")
+                if isinstance(item.system_data, dict)
+                else ""
+            )
+            self.scraper_manager.start_batch(
+                folder_path=folder,
+                roms=roms,
+                default_images=[],
+                auto_select=True,
+                download_video=False,
+                system=system,
+            )
+        except Exception as e:
+            log_error(f"Auto-scrape trigger failed: {e}")
 
     # Comprehensive Batocera system list: (display_name, batocera_folder_id)
     # folder_id maps to ScreenScraper systemeid via SYSTEM_ID_MAP

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -46,6 +46,7 @@ class Settings:
     )
     scraper_provider: str = "libretro"  # libretro, screenscraper, thegamesdb
     scraper_fallback_enabled: bool = True
+    auto_scrape_after_download: bool = False
     scraper_preferred_system: str = ""  # deprecated, now per-batch in wizard
     screenscraper_username: str = ""
     screenscraper_password: str = ""  # base64 encoded

--- a/src/services/auto_scrape.py
+++ b/src/services/auto_scrape.py
@@ -1,0 +1,23 @@
+"""Auto-scrape gating and new-completion detection (GAB-19).
+
+Pure helpers with no project dependencies so they remain trivially testable.
+"""
+
+from typing import Any, Callable, Hashable, Iterable, Mapping
+
+
+def should_auto_scrape(settings: Mapping[str, Any]) -> bool:
+    return (
+        bool(settings.get("auto_scrape_after_download", False))
+        and bool(settings.get("scraper_enabled", False))
+        and settings.get("scraper_provider", "") not in ("", None)
+    )
+
+
+def new_completions(prev_status, items, id_of, status_of) -> list:
+    result = []
+    for item in items:
+        iid = id_of(item)
+        if status_of(item) == "completed" and prev_status.get(iid) != "completed":
+            result.append(iid)
+    return result

--- a/src/ui/screens/settings_screen.py
+++ b/src/ui/screens/settings_screen.py
@@ -72,6 +72,7 @@ class SettingsScreen:
         "--- ARTBOX GAMES SCRAPER ---",
         "Enable Scraper",
         "Scraper Frontend",
+        "Auto-Scrape After Download",
     ]
 
     # NSZ section
@@ -179,6 +180,7 @@ class SettingsScreen:
         items.append(self.SCRAPER_SECTION[1])
         if scraper_enabled:
             items.append(self.SCRAPER_SECTION[2])  # Scraper Frontend
+            items.append(self.SCRAPER_SECTION[3])  # Auto-Scrape After Download
 
         # Add NSZ section
         nsz_enabled = settings.get("nsz_enabled", False)
@@ -320,6 +322,13 @@ class SettingsScreen:
                     "pegasus": "Pegasus",
                 }
                 items.append((item, frontend_labels.get(frontend, frontend)))
+            elif item == "Auto-Scrape After Download":
+                value = (
+                    "ON"
+                    if settings.get("auto_scrape_after_download", False)
+                    else "OFF"
+                )
+                items.append((item, value))
             elif item == "Enable NSZ":
                 value = "ON" if settings.get("nsz_enabled", False) else "OFF"
                 items.append((item, value))
@@ -420,6 +429,7 @@ class SettingsScreen:
                 "Roster Hockey Data Source": "toggle_nhl94_provider",
                 "Enable Scraper": "toggle_scraper_enabled",
                 "Scraper Frontend": "toggle_scraper_frontend",
+                "Auto-Scrape After Download": "toggle_auto_scrape_after_download",
                 "Enable NSZ": "toggle_nsz_enabled",
                 "Web Companion": "toggle_web_companion",
                 "Enable Syncthing Helper": "toggle_syncthing_enabled",

--- a/tests/test_auto_scrape.py
+++ b/tests/test_auto_scrape.py
@@ -1,0 +1,142 @@
+"""Tests for auto-scrape gating and new-completion detection (GAB-19)."""
+
+import importlib.util
+import os
+import sys
+
+# Run headless so importing anything pygame-adjacent never opens a window/audio.
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+# Make src/ importable for parity with the rest of the suite, though we load
+# the module by file path to avoid services/__init__.py side effects.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+_MOD_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "src", "services", "auto_scrape.py"
+)
+
+
+def _load():
+    """Lazily load auto_scrape by file path.
+
+    Loading lazily (inside each test) keeps pytest collection clean: the import
+    error surfaces as a test failure rather than a collection error while
+    src/services/auto_scrape.py does not yet exist.
+    """
+    spec = importlib.util.spec_from_file_location("auto_scrape", _MOD_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Stubs for new_completions.
+_id_of = lambda d: d["id"]
+_status_of = lambda d: d["status"]
+
+
+class TestShouldAutoScrape:
+    def test_all_true(self):
+        should_auto_scrape = _load().should_auto_scrape
+        assert (
+            should_auto_scrape(
+                {
+                    "auto_scrape_after_download": True,
+                    "scraper_enabled": True,
+                    "scraper_provider": "libretro",
+                }
+            )
+            is True
+        )
+
+    def test_auto_flag_false(self):
+        should_auto_scrape = _load().should_auto_scrape
+        assert (
+            should_auto_scrape(
+                {
+                    "auto_scrape_after_download": False,
+                    "scraper_enabled": True,
+                    "scraper_provider": "libretro",
+                }
+            )
+            is False
+        )
+
+    def test_scraper_disabled(self):
+        should_auto_scrape = _load().should_auto_scrape
+        assert (
+            should_auto_scrape(
+                {
+                    "auto_scrape_after_download": True,
+                    "scraper_enabled": False,
+                    "scraper_provider": "libretro",
+                }
+            )
+            is False
+        )
+
+    def test_provider_empty(self):
+        should_auto_scrape = _load().should_auto_scrape
+        assert (
+            should_auto_scrape(
+                {
+                    "auto_scrape_after_download": True,
+                    "scraper_enabled": True,
+                    "scraper_provider": "",
+                }
+            )
+            is False
+        )
+
+    def test_provider_none(self):
+        should_auto_scrape = _load().should_auto_scrape
+        assert (
+            should_auto_scrape(
+                {
+                    "auto_scrape_after_download": True,
+                    "scraper_enabled": True,
+                    "scraper_provider": None,
+                }
+            )
+            is False
+        )
+
+    def test_missing_keys_default_false(self):
+        should_auto_scrape = _load().should_auto_scrape
+        assert should_auto_scrape({}) is False
+
+
+class TestNewCompletions:
+    def test_detects_transition_to_completed(self):
+        new_completions = _load().new_completions
+        prev = {1: "downloading"}
+        items = [{"id": 1, "status": "completed"}]
+        assert new_completions(prev, items, _id_of, _status_of) == [1]
+
+    def test_ignores_already_completed(self):
+        new_completions = _load().new_completions
+        prev = {1: "completed"}
+        items = [{"id": 1, "status": "completed"}]
+        assert new_completions(prev, items, _id_of, _status_of) == []
+
+    def test_ignores_non_completed(self):
+        new_completions = _load().new_completions
+        prev = {}
+        items = [{"id": 1, "status": "downloading"}]
+        assert new_completions(prev, items, _id_of, _status_of) == []
+
+    def test_multiple_items_mixed(self):
+        new_completions = _load().new_completions
+        prev = {1: "completed", 2: "downloading"}
+        items = [
+            {"id": 1, "status": "completed"},
+            {"id": 2, "status": "completed"},
+            {"id": 3, "status": "downloading"},
+        ]
+        assert new_completions(prev, items, _id_of, _status_of) == [2]
+
+    def test_empty_prev_completed_is_new(self):
+        new_completions = _load().new_completions
+        prev = {}
+        items = [{"id": 5, "status": "completed"}]
+        assert new_completions(prev, items, _id_of, _status_of) == [5]


### PR DESCRIPTION
Closes GAB-19.

## Feature
A new opt-in setting that automatically scrapes box art for a game right after its download completes.

## Implementation
- **New pure `src/services/auto_scrape.py`**:
  - `should_auto_scrape(settings)` — gates on `auto_scrape_after_download` **AND** `scraper_enabled` **AND** a configured `scraper_provider`.
  - `new_completions(prev_status, items, id_of, status_of)` — detects items that just **transitioned** to `completed` (prevents re-triggering every frame).
- **`config/settings.py`** — `auto_scrape_after_download: bool = False` (opt-in).
- **`settings_screen.py`** — "Auto-Scrape After Download" toggle, shown under the scraper section when the scraper is enabled (ON/OFF + action), mirroring the existing scraper toggles.
- **`app.py`** — a cheap per-frame completion diff in the main loop; when `should_auto_scrape()` is true it calls `_trigger_auto_scrape(item)` → `scraper_manager.start_batch(..., auto_select=True)` (daemon-threaded, non-interactive). `_trigger_auto_scrape` is **fully `try/except`-wrapped**, so a scrape failure can never affect downloads or the loop. **`DownloadManager` keeps no scraper reference** (no new coupling — triggered from the loop that already watches the queue).

## Tests (TDD)
`tests/test_auto_scrape.py` — 11 tests: `should_auto_scrape` gating (all conditions + defaults) and `new_completions` transition detection (incl. the no-re-trigger case). **Full suite: 188 passed.** QA: PASS — verified no re-trigger-every-frame, `start_batch` signature matches, default-off safety.

## Notes / on-device
Default **off** → zero behavior change unless the user enables both the scraper and this toggle. The actual scrape kick-off (provider/network) is integration and best confirmed on a device with a configured provider.

---
Delivered by the `console-utils-squad` pipeline: Research → CTO → Architect → Tester (TDD) → Developer → QA → PR.