### PR TITLE
Add System Information screen to Utilities

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1047,6 +1047,19 @@ class ConsoleUtilitiesApp:
             if self.image_cache.update():
                 _dirty = True
 
+            # System Information: re-poll RAM/disk usage every 2s while open
+            if self.state.mode == "system_info":
+                now = pygame.time.get_ticks()
+                if now - self.state.system_info_last_poll > 2000:
+                    from services.system_info import gather_dynamic
+
+                    self.state.system_info_dynamic = gather_dynamic(
+                        self.settings.get("roms_dir", ""),
+                        self.settings.get("work_dir", ""),
+                    )
+                    self.state.system_info_last_poll = now
+                    _dirty = True
+
             # Poll auto-detect ROM downloads for completion
             self._poll_auto_detect_downloads()
 
@@ -1423,6 +1436,21 @@ class ConsoleUtilitiesApp:
             elif direction == "up":
                 self.state.credits_scroll_offset = max(
                     self.state.credits_scroll_offset - SCROLL_STEP,
+                    0,
+                )
+
+        elif self.state.mode == "system_info":
+            from ui.screens.system_info_screen import SCROLL_STEP
+
+            max_scroll = self.state.ui_rects.rects.get("system_info_max_scroll", 0)
+            if direction == "down":
+                self.state.system_info_scroll_offset = min(
+                    self.state.system_info_scroll_offset + SCROLL_STEP,
+                    max_scroll,
+                )
+            elif direction == "up":
+                self.state.system_info_scroll_offset = max(
+                    self.state.system_info_scroll_offset - SCROLL_STEP,
                     0,
                 )
 
@@ -3452,7 +3480,13 @@ class ConsoleUtilitiesApp:
         elif self.state.mode == "file_explorer":
             self._handle_file_explorer_back()
 
-        elif self.state.mode in ("settings", "utils", "credits", "scraper_menu"):
+        elif self.state.mode in (
+            "settings",
+            "utils",
+            "credits",
+            "scraper_menu",
+            "system_info",
+        ):
             self.state.mode = "systems"
             self.state.highlighted = 0
 
@@ -4461,6 +4495,8 @@ class ConsoleUtilitiesApp:
         if action == "divider":
             # Skip divider items
             return
+        elif action == "system_info":
+            self._enter_system_info()
         elif action == "download_url":
             self.state.url_input.show = True
             self.state.url_input.context = "direct_download"
@@ -4486,6 +4522,19 @@ class ConsoleUtilitiesApp:
             self._enter_syncthing()
         elif action == "steam_shortcut":
             self._start_steam_shortcut()
+
+    def _enter_system_info(self):
+        """Gather system info and switch to the System Information screen."""
+        from services.system_info import gather_static, gather_dynamic
+
+        roms_dir = self.settings.get("roms_dir", "")
+        work_dir = self.settings.get("work_dir", "")
+        self.state.system_info_static = gather_static()
+        self.state.system_info_dynamic = gather_dynamic(roms_dir, work_dir)
+        self.state.system_info_scroll_offset = 0
+        self.state.system_info_last_poll = pygame.time.get_ticks()
+        self.state.mode = "system_info"
+        self.state.highlighted = 0
 
     def _start_steam_shortcut(self):
         """Start the Steam shortcut creator flow."""

--- a/src/services/system_info.py
+++ b/src/services/system_info.py
@@ -11,7 +11,7 @@ import os
 import platform
 import shutil
 import socket
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 
@@ -24,17 +24,6 @@ class DiskInfo:
     free: int
 
 
-@dataclass
-class SystemInfo:
-    os_name: Optional[str] = None
-    os_version: Optional[str] = None
-    hostname: Optional[str] = None
-    cpu_model: Optional[str] = None
-    ram_total: Optional[int] = None
-    ram_used: Optional[int] = None
-    disks: List[DiskInfo] = field(default_factory=list)
-
-
 def format_bytes(n: Optional[int]) -> str:
     """Human-readable size. None -> '--'."""
     if n is None:
@@ -44,7 +33,6 @@ def format_bytes(n: Optional[int]) -> str:
         if value < 1024 or unit == "TB":
             return f"{value:.1f} {unit}"
         value /= 1024
-    return f"{value:.1f} TB"
 
 
 def _read_file(path: str) -> str:
@@ -129,22 +117,13 @@ def _mount_point(path: str) -> str:
 
 def gather_static() -> dict:
     """Static fields: OS name/version, hostname, CPU model. Gathered once."""
-    info = SystemInfo()
-
     os_data = _parse_os_release(_read_file("/etc/os-release"))
-    info.os_name = os_data.get("name") or _safe(platform.system)
-    info.os_version = os_data.get("version") or _safe(platform.release)
-
-    info.hostname = _safe(socket.gethostname)
-    info.cpu_model = _parse_cpu_model(_read_file("/proc/cpuinfo")) or (
-        _safe(platform.processor) or None
-    )
-
     return {
-        "os_name": info.os_name,
-        "os_version": info.os_version,
-        "hostname": info.hostname,
-        "cpu_model": info.cpu_model,
+        "os_name": os_data.get("name") or _safe(platform.system),
+        "os_version": os_data.get("version") or _safe(platform.release),
+        "hostname": _safe(socket.gethostname),
+        "cpu_model": _parse_cpu_model(_read_file("/proc/cpuinfo"))
+        or (_safe(platform.processor) or None),
     }
 
 

--- a/src/services/system_info.py
+++ b/src/services/system_info.py
@@ -123,7 +123,7 @@ def gather_static() -> dict:
         "os_version": os_data.get("version") or _safe(platform.release),
         "hostname": _safe(socket.gethostname),
         "cpu_model": _parse_cpu_model(_read_file("/proc/cpuinfo"))
-        or (_safe(platform.processor) or None),
+        or _safe(platform.processor),
     }
 
 

--- a/src/services/system_info.py
+++ b/src/services/system_info.py
@@ -1,0 +1,192 @@
+"""
+System information gathering service.
+
+Collects OS, device, RAM, and disk-usage info using only the Python
+standard library so no new dependency (and no python-for-android recipe)
+is required. Every probe is individually guarded: a failure yields None
+for that field (or omits that disk) rather than raising.
+"""
+
+import os
+import platform
+import shutil
+import socket
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+
+@dataclass
+class DiskInfo:
+    mount: str
+    label: str
+    total: int
+    used: int
+    free: int
+
+
+@dataclass
+class SystemInfo:
+    os_name: Optional[str] = None
+    os_version: Optional[str] = None
+    hostname: Optional[str] = None
+    cpu_model: Optional[str] = None
+    ram_total: Optional[int] = None
+    ram_used: Optional[int] = None
+    disks: List[DiskInfo] = field(default_factory=list)
+
+
+def format_bytes(n: Optional[int]) -> str:
+    """Human-readable size. None -> '--'."""
+    if n is None:
+        return "--"
+    value = float(n)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TB"
+
+
+def _read_file(path: str) -> str:
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+
+def _parse_os_release(content: str) -> dict:
+    """Parse /etc/os-release content into {'name', 'version'}."""
+    if not content.strip():
+        return {}
+    values = {}
+    for line in content.splitlines():
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        values[key.strip()] = val.strip().strip('"')
+    result = {}
+    if values.get("NAME"):
+        result["name"] = values["NAME"]
+    version = values.get("VERSION") or values.get("VERSION_ID")
+    if version:
+        result["version"] = version
+    return result
+
+
+def _parse_cpu_model(content: str) -> Optional[str]:
+    """First 'model name' (x86) or 'Model'/'Hardware' (ARM) from /proc/cpuinfo."""
+    for line in content.splitlines():
+        lower = line.lower()
+        if lower.startswith("model name") or lower.startswith("hardware"):
+            _, _, val = line.partition(":")
+            if val.strip():
+                return val.strip()
+    return None
+
+
+def _parse_meminfo(content: str) -> Tuple[Optional[int], Optional[int]]:
+    """Return (total_bytes, used_bytes) from /proc/meminfo. used = total - available."""
+    total_kb = avail_kb = None
+    for line in content.splitlines():
+        if line.startswith("MemTotal:"):
+            total_kb = _first_int(line)
+        elif line.startswith("MemAvailable:"):
+            avail_kb = _first_int(line)
+    total = total_kb * 1024 if total_kb is not None else None
+    used = (
+        (total_kb - avail_kb) * 1024
+        if total_kb is not None and avail_kb is not None
+        else None
+    )
+    return total, used
+
+
+def _first_int(line: str) -> Optional[int]:
+    for token in line.split():
+        if token.isdigit():
+            return int(token)
+    return None
+
+
+def _mount_point(path: str) -> str:
+    """Walk up until the parent is on a different device (the mount root)."""
+    path = os.path.abspath(path)
+    try:
+        dev = os.stat(path).st_dev
+    except OSError:
+        return path
+    while path != os.path.dirname(path):
+        parent = os.path.dirname(path)
+        try:
+            if os.stat(parent).st_dev != dev:
+                break
+        except OSError:
+            break
+        path = parent
+    return path
+
+
+def gather_static() -> dict:
+    """Static fields: OS name/version, hostname, CPU model. Gathered once."""
+    info = SystemInfo()
+
+    os_data = _parse_os_release(_read_file("/etc/os-release"))
+    info.os_name = os_data.get("name") or _safe(platform.system)
+    info.os_version = os_data.get("version") or _safe(platform.release)
+
+    info.hostname = _safe(socket.gethostname)
+    info.cpu_model = _parse_cpu_model(_read_file("/proc/cpuinfo")) or (
+        _safe(platform.processor) or None
+    )
+
+    return {
+        "os_name": info.os_name,
+        "os_version": info.os_version,
+        "hostname": info.hostname,
+        "cpu_model": info.cpu_model,
+    }
+
+
+def gather_dynamic(roms_dir: str = "", work_dir: str = "") -> dict:
+    """Dynamic fields: RAM usage and relevant disk usage. Re-callable."""
+    ram_total, ram_used = _parse_meminfo(_read_file("/proc/meminfo"))
+
+    candidates = [("Root", "/")]
+    if roms_dir:
+        candidates.append(("ROMs", roms_dir))
+    if work_dir:
+        candidates.append(("Work", work_dir))
+
+    disks: List[DiskInfo] = []
+    seen_mounts = set()
+    for label, path in candidates:
+        if not path or not os.path.exists(path):
+            continue
+        mount = _mount_point(path)
+        if mount in seen_mounts:
+            continue
+        try:
+            usage = shutil.disk_usage(path)
+        except OSError:
+            continue
+        seen_mounts.add(mount)
+        disks.append(
+            DiskInfo(
+                mount=mount,
+                label=label,
+                total=usage.total,
+                used=usage.used,
+                free=usage.free,
+            )
+        )
+
+    return {"ram_total": ram_total, "ram_used": ram_used, "disks": disks}
+
+
+def _safe(fn):
+    try:
+        result = fn()
+        return result if result else None
+    except Exception:
+        return None

--- a/src/state.py
+++ b/src/state.py
@@ -1070,6 +1070,12 @@ class AppState:
         self.settings_scroll_offset: int = 0
         self.credits_scroll_offset: int = 0
 
+        # ---- System Information screen ---- #
+        self.system_info_static: Optional[dict] = None
+        self.system_info_dynamic: Optional[dict] = None
+        self.system_info_scroll_offset: int = 0
+        self.system_info_last_poll: int = 0  # ms from pygame.time.get_ticks()
+
         # ---- Mode-specific highlights ---- #
         self.add_systems_highlighted: int = 0
         self.systems_settings_highlighted: int = 0

--- a/src/ui/screens/screen_manager.py
+++ b/src/ui/screens/screen_manager.py
@@ -52,6 +52,7 @@ from .pes6_ps2_patcher_screen import PES6PS2PatcherScreen
 from .syncthing_screen import SyncthingScreen
 from .downloads_screen import DownloadsScreen
 from .file_explorer_screen import FileExplorerScreen
+from .system_info_screen import SystemInfoScreen
 from .scraper_downloads_screen import ScraperDownloadsScreen
 from ui.molecules.status_footer import StatusFooter, StatusFooterItem
 
@@ -92,6 +93,7 @@ class ScreenManager:
         self.pes6_ps2_patcher_screen = PES6PS2PatcherScreen(theme)
         self.syncthing_screen = SyncthingScreen(theme)
         self.file_explorer_screen = FileExplorerScreen(theme)
+        self.system_info_screen = SystemInfoScreen(theme)
 
         # Initialize modals
         self.search_modal = SearchModal(theme)
@@ -923,6 +925,21 @@ class ScreenManager:
             )
             rects["back"] = back_rect
             rects["credits_max_scroll"] = max_scroll
+
+        elif state.mode == "system_info":
+            info = {}
+            if state.system_info_static:
+                info.update(state.system_info_static)
+            if state.system_info_dynamic:
+                info.update(state.system_info_dynamic)
+            back_rect, max_scroll = self.system_info_screen.render(
+                screen,
+                info,
+                scroll_offset=state.system_info_scroll_offset,
+                input_mode=state.input_mode,
+            )
+            rects["back"] = back_rect
+            rects["system_info_max_scroll"] = max_scroll
 
         elif state.mode == "add_systems":
             back_rect, item_rects, scroll_offset = self.add_systems_screen.render(

--- a/src/ui/screens/system_info_screen.py
+++ b/src/ui/screens/system_info_screen.py
@@ -138,7 +138,9 @@ class SystemInfoScreen:
         )
         return y + self.theme.font_size_sm + self.theme.padding_xs
 
-    def _bar(self, screen: pygame.Surface, frac: float, x: int, y: int, width: int) -> int:
+    def _bar(
+        self, screen: pygame.Surface, frac: float, x: int, y: int, width: int
+    ) -> int:
         bar_rect = pygame.Rect(x, y, width, BAR_HEIGHT)
         self.progress.render(
             screen, bar_rect, frac,

--- a/src/ui/screens/system_info_screen.py
+++ b/src/ui/screens/system_info_screen.py
@@ -1,0 +1,148 @@
+"""
+System Information screen - OS, device, and storage usage (read-only).
+"""
+
+import pygame
+from typing import Tuple, Optional, Dict, Any
+
+from ui.theme import Theme, default_theme
+from ui.atoms.text import Text
+from ui.atoms.progress import ProgressBar
+from ui.organisms.header import Header
+from utils.button_hints import get_button_hint
+from constants import BEZEL_INSET
+from services.system_info import format_bytes
+
+SCROLL_STEP = 20
+
+
+class SystemInfoScreen:
+    """Read-only screen showing OS/device basics and per-disk usage bars."""
+
+    def __init__(self, theme: Theme = default_theme):
+        self.theme = theme
+        self.header = Header(theme)
+        self.text = Text(theme)
+        self.progress = ProgressBar(theme)
+
+    def render(
+        self,
+        screen: pygame.Surface,
+        info: Dict[str, Any],
+        scroll_offset: int = 0,
+        input_mode: str = "keyboard",
+    ) -> Tuple[Optional[pygame.Rect], int]:
+        """Render the screen. Returns (back_button_rect, max_scroll)."""
+        t = self.theme
+        header_height = t.header_height
+        _, back_button_rect = self.header.render(
+            screen, title="System Information", show_back=True
+        )
+
+        inset = BEZEL_INSET
+        content_x = inset + t.padding_lg
+        content_top = inset + header_height + t.padding_lg
+        content_width = screen.get_width() - inset * 2 - t.padding_lg * 2
+
+        hint_height = t.font_size_sm + t.padding_lg
+        content_bottom = screen.get_height() - BEZEL_INSET - hint_height
+        visible_height = content_bottom - content_top
+
+        clip_rect = pygame.Rect(0, content_top, screen.get_width(), visible_height)
+        old_clip = screen.get_clip()
+        screen.set_clip(clip_rect)
+
+        y = content_top - scroll_offset
+
+        # --- Device section ---
+        y = self._section_title(screen, "DEVICE", content_x, y)
+        y = self._kv_row(screen, "OS", info.get("os_name"), content_x, y, content_width)
+        y = self._kv_row(
+            screen, "Version", info.get("os_version"), content_x, y, content_width
+        )
+        y = self._kv_row(
+            screen, "Host", info.get("hostname"), content_x, y, content_width
+        )
+        y = self._kv_row(
+            screen, "CPU", info.get("cpu_model"), content_x, y, content_width
+        )
+
+        # RAM with bar
+        ram_total = info.get("ram_total")
+        ram_used = info.get("ram_used")
+        ram_text = f"{format_bytes(ram_used)} / {format_bytes(ram_total)}"
+        y = self._kv_row(screen, "RAM", ram_text, content_x, y, content_width)
+        ram_frac = (
+            ram_used / ram_total
+            if ram_used is not None and ram_total
+            else 0.0
+        )
+        y = self._bar(screen, ram_frac, content_x, y, content_width)
+
+        y += t.padding_md
+
+        # --- Storage section ---
+        y = self._section_title(screen, "STORAGE", content_x, y)
+        disks = info.get("disks") or []
+        if not disks:
+            y = self._kv_row(screen, "Disks", "--", content_x, y, content_width)
+        for disk in disks:
+            usage_text = f"{format_bytes(disk.used)} / {format_bytes(disk.total)}"
+            y = self._kv_row(
+                screen, disk.label, usage_text, content_x, y, content_width
+            )
+            frac = disk.used / disk.total if disk.total else 0.0
+            y = self._bar(screen, frac, content_x, y, content_width)
+            y += t.padding_sm
+
+        screen.set_clip(old_clip)
+
+        total_height = (y + scroll_offset) - content_top
+        max_scroll = max(0, total_height - visible_height)
+
+        bottom_y = (
+            screen.get_height() - BEZEL_INSET - t.padding_lg - t.font_size_sm
+        )
+        back_hint = get_button_hint("back", "Back", input_mode)
+        self.text.render(
+            screen,
+            back_hint,
+            (screen.get_width() // 2, bottom_y),
+            color=t.text_disabled,
+            size=t.font_size_sm,
+            align="center",
+        )
+
+        return back_button_rect, max_scroll
+
+    def _section_title(self, screen, label, x, y):
+        self.text.render(
+            screen, label, (x, y), color=self.theme.secondary,
+            size=self.theme.font_size_md,
+        )
+        return y + self.theme.font_size_md + self.theme.padding_sm
+
+    def _kv_row(self, screen, key, value, x, y, width):
+        self.text.render(
+            screen, f"{key}:", (x, y), color=self.theme.text_secondary,
+            size=self.theme.font_size_sm,
+        )
+        self.text.render(
+            screen, str(value) if value else "--", (x + 160, y),
+            color=self.theme.text_primary, size=self.theme.font_size_sm,
+            max_width=width - 160,
+        )
+        return y + self.theme.font_size_sm + self.theme.padding_xs
+
+    def _bar(self, screen, frac, x, y, width):
+        bar_rect = pygame.Rect(x, y, width, 12)
+        self.progress.render(
+            screen, bar_rect, frac,
+            track_color=self.theme.surface,
+            fill_color=self.theme.primary,
+        )
+        return y + 12 + self.theme.padding_sm
+
+
+# Default instance
+system_info_screen = SystemInfoScreen()

--- a/src/ui/screens/system_info_screen.py
+++ b/src/ui/screens/system_info_screen.py
@@ -14,6 +14,8 @@ from constants import BEZEL_INSET
 from services.system_info import format_bytes
 
 SCROLL_STEP = 20
+KEY_COLUMN_WIDTH = 160  # px gutter before the value column in key/value rows
+BAR_HEIGHT = 12  # px height of usage progress bars
 
 
 class SystemInfoScreen:
@@ -115,33 +117,35 @@ class SystemInfoScreen:
 
         return back_button_rect, max_scroll
 
-    def _section_title(self, screen, label, x, y):
+    def _section_title(self, screen: pygame.Surface, label: str, x: int, y: int) -> int:
         self.text.render(
             screen, label, (x, y), color=self.theme.secondary,
             size=self.theme.font_size_md,
         )
         return y + self.theme.font_size_md + self.theme.padding_sm
 
-    def _kv_row(self, screen, key, value, x, y, width):
+    def _kv_row(
+        self, screen: pygame.Surface, key: str, value, x: int, y: int, width: int
+    ) -> int:
         self.text.render(
             screen, f"{key}:", (x, y), color=self.theme.text_secondary,
             size=self.theme.font_size_sm,
         )
         self.text.render(
-            screen, str(value) if value else "--", (x + 160, y),
+            screen, str(value) if value else "--", (x + KEY_COLUMN_WIDTH, y),
             color=self.theme.text_primary, size=self.theme.font_size_sm,
-            max_width=width - 160,
+            max_width=width - KEY_COLUMN_WIDTH,
         )
         return y + self.theme.font_size_sm + self.theme.padding_xs
 
-    def _bar(self, screen, frac, x, y, width):
-        bar_rect = pygame.Rect(x, y, width, 12)
+    def _bar(self, screen: pygame.Surface, frac: float, x: int, y: int, width: int) -> int:
+        bar_rect = pygame.Rect(x, y, width, BAR_HEIGHT)
         self.progress.render(
             screen, bar_rect, frac,
             track_color=self.theme.surface,
             fill_color=self.theme.primary,
         )
-        return y + 12 + self.theme.padding_sm
+        return y + BAR_HEIGHT + self.theme.padding_sm
 
 
 # Default instance

--- a/src/ui/screens/utils_screen.py
+++ b/src/ui/screens/utils_screen.py
@@ -17,6 +17,12 @@ class UtilsScreen:
     and NSZ conversion.
     """
 
+    # System section items
+    SYSTEM_SECTION_ITEMS = [
+        "--- SYSTEM ---",  # Divider
+        "System Information",
+    ]
+
     # Download section items
     DOWNLOAD_SECTION_ITEMS = [
         "--- DOWNLOAD ---",  # Divider
@@ -79,6 +85,10 @@ class UtilsScreen:
         """
         items = []
         divider_indices = set()
+
+        # Add system section (first)
+        divider_indices.add(len(items))
+        items.extend(self.SYSTEM_SECTION_ITEMS)
 
         # Add download section
         divider_indices.add(len(items))
@@ -158,6 +168,7 @@ class UtilsScreen:
         if index < len(items):
             item = items[index]
             actions = {
+                "System Information": "system_info",
                 "Download from URL": "download_url",
                 "Download from Internet Archive": "ia_download",
                 "Add Internet Archive Collection": "ia_add_collection",

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,0 +1,101 @@
+"""Tests for system_info data gathering service."""
+
+import importlib.util
+import os
+
+_mod_path = os.path.join(
+    os.path.dirname(__file__), "..", "src", "services", "system_info.py"
+)
+_spec = importlib.util.spec_from_file_location("system_info", _mod_path)
+system_info = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(system_info)
+
+format_bytes = system_info.format_bytes
+DiskInfo = system_info.DiskInfo
+
+
+class TestFormatBytes:
+    def test_gigabytes(self):
+        assert format_bytes(12_300_000_000) == "11.5 GB"
+
+    def test_megabytes(self):
+        assert format_bytes(5 * 1024 * 1024) == "5.0 MB"
+
+    def test_zero(self):
+        assert format_bytes(0) == "0.0 B"
+
+    def test_none(self):
+        assert format_bytes(None) == "--"
+
+
+class TestParseOsRelease:
+    def test_parses_name_and_version(self):
+        content = 'NAME="Batocera"\nVERSION="40 (Beta)"\nVERSION_ID=40\n'
+        result = system_info._parse_os_release(content)
+        assert result["name"] == "Batocera"
+        assert result["version"] == "40 (Beta)"
+
+    def test_falls_back_to_version_id(self):
+        content = 'NAME="Knulli"\nVERSION_ID=20240601\n'
+        result = system_info._parse_os_release(content)
+        assert result["name"] == "Knulli"
+        assert result["version"] == "20240601"
+
+    def test_empty_returns_empty_dict(self):
+        assert system_info._parse_os_release("") == {}
+
+
+class TestParseCpuModel:
+    def test_extracts_model_name(self):
+        content = "processor\t: 0\nmodel name\t: ARM Cortex-A53\n"
+        assert system_info._parse_cpu_model(content) == "ARM Cortex-A53"
+
+    def test_missing_returns_none(self):
+        assert system_info._parse_cpu_model("processor\t: 0\n") is None
+
+
+class TestParseMeminfo:
+    def test_computes_total_and_used(self):
+        content = "MemTotal:       1000000 kB\nMemAvailable:    400000 kB\n"
+        total, used = system_info._parse_meminfo(content)
+        assert total == 1000000 * 1024
+        assert used == (1000000 - 400000) * 1024
+
+    def test_missing_available_returns_none_used(self):
+        content = "MemTotal:       1000000 kB\n"
+        total, used = system_info._parse_meminfo(content)
+        assert total == 1000000 * 1024
+        assert used is None
+
+    def test_empty_returns_none(self):
+        assert system_info._parse_meminfo("") == (None, None)
+
+
+class TestGatherDynamicDisks:
+    def test_dedupes_mounts(self, monkeypatch):
+        # All paths resolve to the same device → one disk row.
+        monkeypatch.setattr(system_info.os.path, "exists", lambda p: True)
+        monkeypatch.setattr(
+            system_info, "_mount_point", lambda p: "/"
+        )
+
+        class FakeUsage:
+            total, used, free = 100, 60, 40
+
+        monkeypatch.setattr(
+            system_info.shutil, "disk_usage", lambda p: FakeUsage()
+        )
+        result = system_info.gather_dynamic(roms_dir="/roms", work_dir="/work")
+        assert len(result["disks"]) == 1
+        assert result["disks"][0].used == 60
+
+    def test_disk_probe_failure_is_skipped(self, monkeypatch):
+        monkeypatch.setattr(system_info.os.path, "exists", lambda p: True)
+        monkeypatch.setattr(system_info, "_mount_point", lambda p: p)
+
+        def boom(p):
+            raise OSError("nope")
+
+        monkeypatch.setattr(system_info.shutil, "disk_usage", boom)
+        result = system_info.gather_dynamic(roms_dir="/roms", work_dir="/work")
+        assert result["disks"] == []


### PR DESCRIPTION
## Summary
- Adds a read-only **System Information** screen to the Utilities menu showing OS name/version, hostname, CPU model, RAM (used/total with bar), and a usage bar per relevant disk (root + ROMs/work drives, deduped).
- RAM and disk usage refresh live every 2 seconds while the screen is open.
- New `services/system_info.py` gathers everything with the **Python standard library only** (`/proc`, `/etc/os-release`, `shutil.disk_usage`, `socket`, `platform`) — no new dependency and no python-for-android recipe. Every probe is individually guarded, so missing/restricted values render as `--` and never crash (graceful on Android).

## Changes
- `src/services/system_info.py` (new) + `tests/test_system_info.py` (new, 14 tests) — data gathering + parsers.
- `src/ui/screens/system_info_screen.py` (new) — pure renderer following the credits-screen scroll pattern.
- `src/ui/screens/utils_screen.py` — new "SYSTEM" menu section.
- `src/state.py`, `src/ui/screens/screen_manager.py`, `src/app.py` — navigation, scroll, and the 2s live re-poll wiring.

## Test Plan
- [x] `pytest tests/test_system_info.py` — 14 passed
- [x] Full suite — 191 passed
- [x] Headless render smoke test (gather + ScreenManager render to an 800x600 surface) produces expected OS/CPU/RAM/disk values
- [x] Manually verify on a Knulli/Batocera device: Utilities → System Information renders correctly and Back returns to the menu