### PR TITLE
fix(GAB-53): stop Android keyboard from covering IA modals

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -6143,6 +6143,10 @@ class ConsoleUtilitiesApp:
             self._submit_folder_name()
         elif self.state.ia_login.show:
             self._handle_ia_login_ok()
+        elif self.state.ia_download_wizard.show:
+            self._handle_ia_download_wizard_ok()
+        elif self.state.ia_collection_wizard.show:
+            self._handle_ia_collection_wizard_ok()
 
     def _handle_text_modal_cancel_click(self):
         """Handle Cancel button click on text input modals."""
@@ -6165,6 +6169,40 @@ class ConsoleUtilitiesApp:
             self.state.ia_login.password = ""
             self.state.ia_login.cursor_position = 0
             self.state.ia_login.error_message = ""
+
+    def _handle_ia_download_wizard_ok(self):
+        """Handle OK button tap on Android IA download wizard text steps."""
+        if self.state.ia_download_wizard.step == "url":
+            if self.state.ia_download_wizard.url:
+                self._validate_ia_download_item()
+
+    def _handle_ia_collection_wizard_ok(self):
+        """Handle OK button tap on Android IA collection wizard text steps."""
+        wizard = self.state.ia_collection_wizard
+        step = wizard.step
+
+        if step == "url":
+            if wizard.url:
+                self._validate_ia_collection_item()
+        elif step == "name":
+            if wizard.collection_name:
+                self._open_ia_collection_folder_browser()
+        elif step == "folder":
+            if wizard.folder_name:
+                wizard.step = "formats"
+            elif not self.state.folder_browser.show:
+                self._open_ia_collection_folder_browser()
+        elif step == "formats" and wizard.adding_custom_format:
+            if wizard.custom_format_input:
+                fmt = wizard.custom_format_input
+                if not fmt.startswith("."):
+                    fmt = "." + fmt
+                if fmt not in wizard.available_formats:
+                    wizard.available_formats.append(fmt)
+                    wizard.selected_formats.add(len(wizard.available_formats) - 1)
+            wizard.adding_custom_format = False
+            wizard.custom_format_input = ""
+            wizard.cursor_position = 0
 
     def _handle_text_modal_backspace(self):
         """Handle backspace button tap on Android text input modals."""
@@ -6206,6 +6244,26 @@ class ConsoleUtilitiesApp:
                 self.state.folder_name_input.input_text = (
                     self.state.folder_name_input.input_text[:-1]
                 )
+        elif self.state.ia_download_wizard.show:
+            if (
+                self.state.ia_download_wizard.step == "url"
+                and self.state.ia_download_wizard.url
+            ):
+                self.state.ia_download_wizard.url = (
+                    self.state.ia_download_wizard.url[:-1]
+                )
+        elif self.state.ia_collection_wizard.show:
+            wizard = self.state.ia_collection_wizard
+            step = wizard.step
+            if step == "formats" and wizard.adding_custom_format:
+                if wizard.custom_format_input:
+                    wizard.custom_format_input = wizard.custom_format_input[:-1]
+            elif step == "url" and wizard.url:
+                wizard.url = wizard.url[:-1]
+            elif step == "name" and wizard.collection_name:
+                wizard.collection_name = wizard.collection_name[:-1]
+            elif step == "folder" and wizard.folder_name:
+                wizard.folder_name = wizard.folder_name[:-1]
 
     def _apply_search_filter(self):
         """Apply search filter and close search modal."""

--- a/src/ui/screens/modals/ia_collection_modal.py
+++ b/src/ui/screens/modals/ia_collection_modal.py
@@ -8,6 +8,7 @@ from typing import Tuple, List, Optional, Dict, Any, Set
 from ui.theme import Theme, default_theme
 from ui.organisms.modal_frame import ModalFrame
 from ui.organisms.char_keyboard import CharKeyboard
+from ui.molecules.action_button import ActionButton
 from ui.atoms.text import Text
 from utils.button_hints import get_combined_hints
 
@@ -30,7 +31,11 @@ class IACollectionModal:
         self.theme = theme
         self.modal_frame = ModalFrame(theme)
         self.char_keyboard = CharKeyboard(theme)
+        self.action_button = ActionButton(theme)
         self.text = Text(theme)
+        self.ok_rect = None
+        self.cancel_rect = None
+        self.backspace_rect = None
 
     def render(
         self,
@@ -61,9 +66,10 @@ class IACollectionModal:
         Returns:
             Tuple of (modal_rect, content_rect, close_rect, char_rects, item_rects)
         """
-        # Android uses native soft keyboard — render like keyboard mode
-        if input_mode == "android":
-            input_mode = "keyboard"
+        # Reset button rects so stale touch targets don't leak across frames
+        self.ok_rect = None
+        self.cancel_rect = None
+        self.backspace_rect = None
 
         if step == "url":
             rects = self._render_url_step(
@@ -133,6 +139,15 @@ class IACollectionModal:
     ) -> Tuple[pygame.Rect, pygame.Rect, Optional[pygame.Rect], List[Tuple]]:
         """Render collection ID input step."""
         title = "Add Internet Archive Collection"
+
+        if input_mode == "android":
+            return self._render_android_mode_text_input(
+                screen,
+                title,
+                "Enter Item ID:",
+                collection_id,
+                "e.g., myrient_sony_psx",
+            )
 
         if input_mode == "keyboard":
             return self._render_keyboard_input(
@@ -223,6 +238,15 @@ class IACollectionModal:
         """Render collection name input step."""
         title = "Add Internet Archive Collection"
 
+        if input_mode == "android":
+            return self._render_android_mode_text_input(
+                screen,
+                title,
+                "Collection display name:",
+                name,
+                "e.g., My Collection",
+            )
+
         if input_mode == "keyboard":
             return self._render_keyboard_input(
                 screen,
@@ -280,6 +304,15 @@ class IACollectionModal:
     ) -> Tuple[pygame.Rect, pygame.Rect, Optional[pygame.Rect], List[Tuple]]:
         """Render folder name input step."""
         title = "Add Internet Archive Collection"
+
+        if input_mode == "android":
+            return self._render_android_mode_text_input(
+                screen,
+                title,
+                "ROM folder name:",
+                folder,
+                "e.g., my_collection",
+            )
 
         if input_mode == "keyboard":
             return self._render_keyboard_input(
@@ -421,6 +454,141 @@ class IACollectionModal:
 
         return modal_rect, content_rect, None, []
 
+    def _render_android_mode_text_input(
+        self,
+        screen: pygame.Surface,
+        title: str,
+        label: str,
+        value: str,
+        placeholder: str,
+    ) -> Tuple[pygame.Rect, pygame.Rect, Optional[pygame.Rect], List[Tuple]]:
+        """Render text input for Android (top-aligned, OK/Cancel buttons).
+
+        Anchors the modal near the top so the native soft keyboard does not
+        cover it. Stores ok_rect / cancel_rect / backspace_rect for touch.
+        """
+        sw, sh = screen.get_size()
+        width = min(int(sw * 0.9), 600)
+        height = 230
+
+        modal_rect, content_rect, close_rect = self.modal_frame.render_top_aligned(
+            screen, width, height, title=title, show_close=False
+        )
+
+        padding = self.theme.padding_sm
+
+        # Label above the field
+        self.text.render(
+            screen,
+            label,
+            (content_rect.left + padding, content_rect.top + padding),
+            color=self.theme.text_secondary,
+            size=self.theme.font_size_sm,
+        )
+
+        y = content_rect.top + padding + 25
+
+        # Draw input field with backspace button (larger for touch)
+        field_height = 48
+        bksp_width = 48
+        field_rect = pygame.Rect(
+            content_rect.left + padding,
+            y,
+            content_rect.width - padding * 3 - bksp_width,
+            field_height,
+        )
+
+        pygame.draw.rect(
+            screen,
+            self.theme.surface_hover,
+            field_rect,
+            border_radius=self.theme.radius_sm,
+        )
+
+        # Backspace button
+        bksp_rect = pygame.Rect(
+            field_rect.right + padding,
+            y,
+            bksp_width,
+            field_height,
+        )
+        pygame.draw.rect(
+            screen,
+            self.theme.surface_hover,
+            bksp_rect,
+            border_radius=self.theme.radius_sm,
+        )
+        self.text.render(
+            screen,
+            "<x]",
+            (bksp_rect.centerx, bksp_rect.centery - self.theme.font_size_md // 2),
+            color=self.theme.text_primary,
+            size=self.theme.font_size_md,
+            align="center",
+        )
+        self.backspace_rect = bksp_rect
+
+        # Draw text
+        display_text = value if value else placeholder
+        text_color = self.theme.text_primary if value else self.theme.text_disabled
+        self.text.render(
+            screen,
+            display_text,
+            (
+                field_rect.left + padding,
+                field_rect.centery - self.theme.font_size_md // 2,
+            ),
+            color=text_color,
+            size=self.theme.font_size_md,
+            max_width=field_rect.width - padding * 2,
+        )
+
+        # Draw cursor
+        if value:
+            cursor_x = (
+                field_rect.left
+                + padding
+                + self.text.measure(value, self.theme.font_size_md)[0]
+                + 2
+            )
+        else:
+            cursor_x = field_rect.left + padding
+
+        pygame.draw.line(
+            screen,
+            self.theme.primary,
+            (cursor_x, field_rect.top + 8),
+            (cursor_x, field_rect.bottom - 8),
+            2,
+        )
+
+        # Draw OK and Cancel buttons
+        y = field_rect.bottom + padding * 3
+        button_width = 120
+        button_height = 44
+        button_spacing = self.theme.padding_lg
+
+        ok_rect = pygame.Rect(
+            content_rect.centerx - button_width - button_spacing // 2,
+            y,
+            button_width,
+            button_height,
+        )
+        cancel_rect = pygame.Rect(
+            content_rect.centerx + button_spacing // 2,
+            y,
+            button_width,
+            button_height,
+        )
+
+        self.action_button.render(screen, ok_rect, "OK", hover=True)
+        self.action_button.render_secondary(screen, cancel_rect, "Cancel", hover=False)
+
+        self.ok_rect = ok_rect
+        self.cancel_rect = cancel_rect
+
+        return modal_rect, content_rect, None, []
+
     def _render_formats_step(
         self,
         screen: pygame.Surface,
@@ -556,6 +724,18 @@ class IACollectionModal:
         pygame.Rect, pygame.Rect, Optional[pygame.Rect], List[Tuple], List[pygame.Rect]
     ]:
         """Render custom format input."""
+        if input_mode == "android":
+            return (
+                *self._render_android_mode_text_input(
+                    screen,
+                    "Add Custom Format",
+                    "Enter file extension:",
+                    custom_format,
+                    "e.g., .7z",
+                ),
+                [],
+            )
+
         if input_mode == "keyboard":
             rects = self._render_keyboard_input(
                 screen,

--- a/src/ui/screens/modals/ia_download_modal.py
+++ b/src/ui/screens/modals/ia_download_modal.py
@@ -8,6 +8,7 @@ from typing import Tuple, List, Optional, Dict, Any
 from ui.theme import Theme, default_theme
 from ui.organisms.modal_frame import ModalFrame
 from ui.organisms.char_keyboard import CharKeyboard
+from ui.molecules.action_button import ActionButton
 from ui.atoms.text import Text
 from ui.atoms.button import Button
 from utils.button_hints import get_combined_hints
@@ -32,6 +33,10 @@ class IADownloadModal:
         self.char_keyboard = CharKeyboard(theme)
         self.text = Text(theme)
         self.button = Button(theme)
+        self.action_button = ActionButton(theme)
+        self.ok_rect = None
+        self.cancel_rect = None
+        self.backspace_rect = None
 
     def render(
         self,
@@ -63,9 +68,10 @@ class IADownloadModal:
             Tuple of (modal_rect, content_rect, close_rect,
                        char_rects, item_rects)
         """
-        # Android uses native soft keyboard — render like keyboard mode
-        if input_mode == "android":
-            input_mode = "keyboard"
+        # Reset button rects so stale touch targets don't leak across frames
+        self.ok_rect = None
+        self.cancel_rect = None
+        self.backspace_rect = None
 
         if step == "url":
             rects = self._render_url_step(
@@ -115,6 +121,9 @@ class IADownloadModal:
     ) -> Tuple[pygame.Rect, pygame.Rect, Optional[pygame.Rect], List[Tuple]]:
         """Render URL input step."""
         title = "Download from Internet Archive"
+
+        if input_mode == "android":
+            return self._render_android_mode_url_input(screen, url)
 
         if input_mode == "keyboard":
             return self._render_keyboard_url_input(screen, url, input_mode)
@@ -247,6 +256,140 @@ class IADownloadModal:
             size=self.theme.font_size_sm,
             align="center",
         )
+
+        return modal_rect, content_rect, None, []
+
+    def _render_android_mode_url_input(
+        self, screen: pygame.Surface, url: str
+    ) -> Tuple[pygame.Rect, pygame.Rect, Optional[pygame.Rect], List[Tuple]]:
+        """Render URL input for Android (top-aligned, OK/Cancel buttons).
+
+        Anchors the modal near the top so the native soft keyboard does not
+        cover it. Stores ok_rect / cancel_rect / backspace_rect for touch.
+        """
+        title = "Download from Internet Archive"
+        label = "Enter Item ID:"
+        placeholder = "e.g., myrient_sony_psx"
+
+        sw, sh = screen.get_size()
+        width = min(int(sw * 0.9), 600)
+        height = 230
+
+        modal_rect, content_rect, close_rect = self.modal_frame.render_top_aligned(
+            screen, width, height, title=title, show_close=False
+        )
+
+        padding = self.theme.padding_sm
+
+        # Label above the field
+        self.text.render(
+            screen,
+            label,
+            (content_rect.left + padding, content_rect.top + padding),
+            color=self.theme.text_secondary,
+            size=self.theme.font_size_sm,
+        )
+
+        y = content_rect.top + padding + 25
+
+        # Draw input field with backspace button (larger for touch)
+        field_height = 48
+        bksp_width = 48
+        field_rect = pygame.Rect(
+            content_rect.left + padding,
+            y,
+            content_rect.width - padding * 3 - bksp_width,
+            field_height,
+        )
+
+        pygame.draw.rect(
+            screen,
+            self.theme.surface_hover,
+            field_rect,
+            border_radius=self.theme.radius_sm,
+        )
+
+        # Backspace button
+        bksp_rect = pygame.Rect(
+            field_rect.right + padding,
+            y,
+            bksp_width,
+            field_height,
+        )
+        pygame.draw.rect(
+            screen,
+            self.theme.surface_hover,
+            bksp_rect,
+            border_radius=self.theme.radius_sm,
+        )
+        self.text.render(
+            screen,
+            "<x]",
+            (bksp_rect.centerx, bksp_rect.centery - self.theme.font_size_md // 2),
+            color=self.theme.text_primary,
+            size=self.theme.font_size_md,
+            align="center",
+        )
+        self.backspace_rect = bksp_rect
+
+        # Draw text
+        display_text = url if url else placeholder
+        text_color = self.theme.text_primary if url else self.theme.text_disabled
+        self.text.render(
+            screen,
+            display_text,
+            (
+                field_rect.left + padding,
+                field_rect.centery - self.theme.font_size_md // 2,
+            ),
+            color=text_color,
+            size=self.theme.font_size_md,
+            max_width=field_rect.width - padding * 2,
+        )
+
+        # Draw cursor
+        if url:
+            cursor_x = (
+                field_rect.left
+                + padding
+                + self.text.measure(url, self.theme.font_size_md)[0]
+                + 2
+            )
+        else:
+            cursor_x = field_rect.left + padding
+
+        pygame.draw.line(
+            screen,
+            self.theme.primary,
+            (cursor_x, field_rect.top + 8),
+            (cursor_x, field_rect.bottom - 8),
+            2,
+        )
+
+        # Draw OK and Cancel buttons
+        y = field_rect.bottom + padding * 3
+        button_width = 120
+        button_height = 44
+        button_spacing = self.theme.padding_lg
+
+        ok_rect = pygame.Rect(
+            content_rect.centerx - button_width - button_spacing // 2,
+            y,
+            button_width,
+            button_height,
+        )
+        cancel_rect = pygame.Rect(
+            content_rect.centerx + button_spacing // 2,
+            y,
+            button_width,
+            button_height,
+        )
+
+        self.action_button.render(screen, ok_rect, "OK", hover=True)
+        self.action_button.render_secondary(screen, cancel_rect, "Cancel", hover=False)
+
+        self.ok_rect = ok_rect
+        self.cancel_rect = cancel_rect
 
         return modal_rect, content_rect, None, []
 

--- a/src/ui/screens/screen_manager.py
+++ b/src/ui/screens/screen_manager.py
@@ -386,6 +386,11 @@ class ScreenManager:
             rects["close"] = close_rect
             rects["char_rects"] = char_rects
             rects["item_rects"] = item_rects
+            if getattr(self.ia_download_modal, "ok_rect", None):
+                rects["text_ok"] = self.ia_download_modal.ok_rect
+                rects["text_cancel"] = self.ia_download_modal.cancel_rect
+            if getattr(self.ia_download_modal, "backspace_rect", None):
+                rects["text_backspace"] = self.ia_download_modal.backspace_rect
             return rects
 
         if state.ia_collection_wizard.show:
@@ -415,6 +420,11 @@ class ScreenManager:
             rects["close"] = close_rect
             rects["char_rects"] = char_rects
             rects["item_rects"] = item_rects
+            if getattr(self.ia_collection_modal, "ok_rect", None):
+                rects["text_ok"] = self.ia_collection_modal.ok_rect
+                rects["text_cancel"] = self.ia_collection_modal.cancel_rect
+            if getattr(self.ia_collection_modal, "backspace_rect", None):
+                rects["text_backspace"] = self.ia_collection_modal.backspace_rect
             return rects
 
         if state.scraper_login.show:

--- a/tests/test_ia_modal_android.py
+++ b/tests/test_ia_modal_android.py
@@ -1,0 +1,164 @@
+"""GAB-53: Internet Archive modals must anchor to the top on Android.
+
+Bug: ia_collection_modal.render() and ia_download_modal.render() clobber
+input_mode == "android" -> "keyboard" before any step routing. The android
+path is never reachable, so text-input steps render centered (top ~210) and
+the Android soft keyboard covers the modal. After the fix, text-input steps
+must use render_top_aligned(), placing the modal at BEZEL_INSET + 10 == 36px
+from the top, while non-input steps (confirm, file_select) stay centered.
+
+These tests assert the chosen code path via the returned modal_rect.top and
+the exported touch-target rects (ok_rect / cancel_rect / backspace_rect).
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+# Drop pytest's argv tail so nsz import-time arg parsing doesn't crash.
+sys.argv = sys.argv[:1]
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+sys.path.insert(0, _SRC)
+
+import pygame  # noqa: E402
+
+
+def _load_module(name, relpath):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_SRC, relpath)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_collection_mod = _load_module(
+    "ia_collection_modal", "ui/screens/modals/ia_collection_modal.py"
+)
+_download_mod = _load_module(
+    "ia_download_modal", "ui/screens/modals/ia_download_modal.py"
+)
+
+IACollectionModal = _collection_mod.IACollectionModal
+IADownloadModal = _download_mod.IADownloadModal
+
+# BEZEL_INSET (26) + 10 == 36; the y that render_top_aligned places modals at.
+TOP_ALIGNED_Y = 36
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _pygame_init():
+    pygame.init()
+    pygame.font.init()
+    yield
+    pygame.quit()
+
+
+@pytest.fixture
+def screen():
+    return pygame.Surface((800, 600))
+
+
+def _render_collection(modal, screen, step):
+    return modal.render(
+        screen,
+        step=step,
+        url="testid",
+        item_id="testid",
+        collection_name="My Collection",
+        folder_name="my_collection",
+        available_formats=[],
+        selected_formats=set(),
+        format_highlighted=0,
+        should_unzip=False,
+        cursor_position=0,
+        error_message="",
+        input_mode="android",
+    )
+
+
+def _render_download(modal, screen, step):
+    return modal.render(
+        screen,
+        step=step,
+        url="testid",
+        item_id="testid",
+        files_list=[],
+        selected_file_index=0,
+        output_folder="",
+        should_extract=False,
+        cursor_position=0,
+        error_message="",
+        input_mode="android",
+    )
+
+
+class TestTextInputStepsTopAligned:
+    """Criteria 1-4: text-input steps anchor to the top on Android."""
+
+    def test_collection_url_step_top_aligned(self, screen):
+        modal = IACollectionModal()
+        result = _render_collection(modal, screen, "url")
+        assert result[0].top == TOP_ALIGNED_Y
+
+    def test_collection_name_step_top_aligned(self, screen):
+        modal = IACollectionModal()
+        result = _render_collection(modal, screen, "name")
+        assert result[0].top == TOP_ALIGNED_Y
+
+    def test_collection_folder_step_top_aligned(self, screen):
+        modal = IACollectionModal()
+        result = _render_collection(modal, screen, "folder")
+        assert result[0].top == TOP_ALIGNED_Y
+
+    def test_download_url_step_top_aligned(self, screen):
+        modal = IADownloadModal()
+        result = _render_download(modal, screen, "url")
+        assert result[0].top == TOP_ALIGNED_Y
+
+
+class TestNonInputStepsStayCentered:
+    """Criteria 5-6: list/confirm steps must NOT be top-aligned."""
+
+    def test_collection_confirm_step_centered(self, screen):
+        modal = IACollectionModal()
+        result = _render_collection(modal, screen, "confirm")
+        assert result[0].top != TOP_ALIGNED_Y
+
+    def test_download_file_select_step_centered(self, screen):
+        modal = IADownloadModal()
+        result = _render_download(modal, screen, "file_select")
+        assert result[0].top != TOP_ALIGNED_Y
+
+
+class TestTouchRectExport:
+    """Criteria 7-8: touch rects exported on input steps, reset otherwise."""
+
+    def test_collection_input_step_exports_rects(self, screen):
+        modal = IACollectionModal()
+        _render_collection(modal, screen, "url")
+        assert modal.ok_rect is not None
+        assert modal.cancel_rect is not None
+        assert modal.backspace_rect is not None
+
+    def test_download_input_step_exports_rects(self, screen):
+        modal = IADownloadModal()
+        _render_download(modal, screen, "url")
+        assert modal.ok_rect is not None
+        assert modal.cancel_rect is not None
+        assert modal.backspace_rect is not None
+
+    def test_collection_non_input_step_resets_rects(self, screen):
+        modal = IACollectionModal()
+        # Prior input-step render populates rects...
+        _render_collection(modal, screen, "url")
+        # ...then a non-input step must clear them (no stale touch targets).
+        _render_collection(modal, screen, "confirm")
+        assert modal.ok_rect is None


### PR DESCRIPTION
## Ticket
GAB-53 — [Android] Utilities page keyboard covers modal during Internet Archive actions
https://linear.app/gabmoterani/issue/GAB-53/android-utilities-page-keyboard-covers-modal-during-internet-archive

## Problem
On Android, opening the on-screen keyboard during Internet Archive Collection and Internet Archive Download actions left the modal hidden behind the keyboard. The user could not see the modal content while typing.

## Root cause
`ia_collection_modal.render()` and `ia_download_modal.render()` forced `input_mode == "android"` into the `"keyboard"` branch, which laid the on-screen keyboard over the modal instead of repositioning the modal above it.

## Fix
- Removed the `android -> keyboard` clobber in both modals; each `render()` now resets `ok_rect/cancel_rect/backspace_rect = None` at the top.
- Android text-input steps now route through `render_top_aligned(... 600, 230 ...)` before the `if input_mode == "keyboard"` branch, landing the modal at top == 36 so it stays visible above the keyboard. Non-input steps (confirm, options, file_select, error) remain centered.
- `_render_custom_format_input` android branch returns the expected 5-tuple.
- Wired `text_ok/text_cancel/text_backspace` for both IA modals in `screen_manager`, mirroring the search_modal pattern.
- Added touch dispatch in `app.py` plus `_handle_ia_download_wizard_ok` and `_handle_ia_collection_wizard_ok`, reusing the keyboard-path advance logic and covering url/name/folder/custom_format backspace; cancel uses existing `_go_back`.

Files:
- src/app.py
- src/ui/screens/modals/ia_collection_modal.py
- src/ui/screens/modals/ia_download_modal.py
- src/ui/screens/screen_manager.py
- tests/test_ia_modal_android.py (added)

## Testing
- Ticket test: `tests/test_ia_modal_android.py` — 9 passed in 0.11s
- Full suite: 278 passed, 3 warnings in 4.03s (3 warnings are pre-existing Pillow deprecations in tests/test_flag_analyzer_mvp.py, unrelated)

## QA verdict
VERDICT: PASS. Adversarial root-cause verification confirmed the input_mode clobber removal and top-aligned routing for all input steps; non-input steps stay centered with ok_rect reset to None. Wiring verified across screen_manager and app.py touch dispatch. No defects found. Cleared for merge.