### PR TITLE
fix(GAB-58): add NSZ debug logging and gitignore nsz.log artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ py_downloads/
 roms/
 config.json
 error.log
+nsz.log
 added_systems.json
 controller_mapping.json
 

--- a/src/services/download_manager.py
+++ b/src/services/download_manager.py
@@ -16,7 +16,7 @@ from zipfile import ZipFile
 import requests
 
 from state import DownloadQueueItem, DownloadQueueState
-from utils.logging import log_error
+from utils.logging import log_error, log_nsz
 from utils.nsz import decompress_nsz_file
 from constants import SCRIPT_DIR
 
@@ -714,8 +714,16 @@ class DownloadManager:
 
                 keys_path = self.settings.get("nsz_keys_path", "")
                 os.makedirs(roms_folder, exist_ok=True)
+                log_nsz(
+                    f"NSZ call (download_manager): file={filename} path={file_path} "
+                    f"size={os.path.getsize(file_path) if os.path.exists(file_path) else -1} "
+                    f"keys_set={bool(keys_path)}"
+                )
                 success = decompress_nsz_file(
                     file_path, roms_folder, keys_path, nsz_progress
+                )
+                log_nsz(
+                    f"NSZ call result (download_manager): file={filename} success={success}"
                 )
 
                 if success:

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -13,11 +13,17 @@ from constants import TEMP_LOG_DIR
 
 # Module-level log file path
 _log_file: str = os.path.join(TEMP_LOG_DIR, "error.log")
+_nsz_log_file: str = os.path.join(TEMP_LOG_DIR, "nsz.log")
 
 
 def get_log_file() -> str:
     """Get the current log file path."""
     return _log_file
+
+
+def get_nsz_log_file() -> str:
+    """Get the current NSZ log file path."""
+    return _nsz_log_file
 
 
 def _write_fallback(text: str) -> None:
@@ -75,6 +81,47 @@ def log_error(
             f.write(file_message)
     except OSError as e:
         print(f"Failed to write log to {_log_file}: {e}", file=sys.stderr, flush=True)
+        _write_fallback(file_message)
+
+
+def log_nsz(
+    error_msg: str,
+    error_type: Optional[str] = None,
+    traceback_str: Optional[str] = None,
+) -> None:
+    """
+    Log an NSZ diagnostic message to the dedicated NSZ log file and stdout.
+
+    Mirrors ``log_error`` but targets ``_nsz_log_file`` so NSZ decompression
+    diagnostics land in their own ``nsz.log`` (sibling of ``error.log``) and
+    never pollute the general error log. On a primary-write OSError it routes
+    the entry through the hardened ``_write_fallback`` path.
+
+    Args:
+        error_msg: The message to log
+        error_type: Optional error type/class name
+        traceback_str: Optional traceback string
+    """
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    log_message = f"[{timestamp}] {error_msg}"
+
+    if error_type:
+        log_message += f" | {error_type}"
+
+    # Always print to stdout (captured by web companion's _LogCapture)
+    print(log_message, flush=True)
+
+    # Build full file entry with traceback
+    file_message = log_message + "\n"
+    if traceback_str:
+        file_message += f"Traceback:\n{traceback_str}\n"
+    file_message += "-" * 80 + "\n"
+
+    try:
+        with open(_nsz_log_file, "a") as f:
+            f.write(file_message)
+    except OSError as e:
+        print(f"Failed to write log to {_nsz_log_file}: {e}", file=sys.stderr, flush=True)
         _write_fallback(file_message)
 
 

--- a/src/utils/nsz.py
+++ b/src/utils/nsz.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 from typing import Callable, Optional
 
-from .logging import log_error
+from .logging import log_nsz
 
 # Try to import NSZ module
 try:
@@ -107,8 +107,12 @@ def decompress_nsz_file(
     """
     filename = os.path.basename(nsz_file_path)
 
-    log_error(f"NSZ Called for {filename}")
-    log_error("NSZ Starting Checks:")
+    log_nsz(f"NSZ start: file={filename} path={nsz_file_path}")
+    log_nsz(f"NSZ keys_path={keys_path!r}")
+    if os.path.exists(nsz_file_path):
+        log_nsz(f"NSZ file_size={os.path.getsize(nsz_file_path)}")
+    else:
+        log_nsz("NSZ file_size=unknown (path does not exist)")
 
     def update_progress(message: str, progress: int):
         if progress_callback:
@@ -116,24 +120,26 @@ def decompress_nsz_file(
         else:
             print(message)
 
-    log_error(f"NSZ Key Path: {keys_path}")
-
     # Check if NSZ library is available
     local_nsz_decompress = _nsz_decompress
-    log_error(f"NSZ exists? : {local_nsz_decompress is not None}")
+    log_nsz(f"NSZ exists? : {local_nsz_decompress is not None}")
 
     if local_nsz_decompress is None:
         try:
             from nsz import decompress as local_nsz_decompress
 
-            log_error("IMPORTED NSZ AGAIN")
+            log_nsz("IMPORTED NSZ AGAIN")
         except (ImportError, AttributeError) as e:
-            log_error(f"NSZ IMPORT ERROR: {str(e)}")
+            log_nsz(f"NSZ IMPORT ERROR: {str(e)}")
             local_nsz_decompress = None
 
     nsz_success = False
 
-    if keys_path and local_nsz_decompress:
+    if not keys_path:
+        log_nsz("NSZ skipped: keys_path not set")
+    elif local_nsz_decompress is None:
+        log_nsz("NSZ skipped: nsz library unavailable")
+    else:
         try:
             update_progress(f"Decompressing {filename}...", 0)
 
@@ -145,7 +151,7 @@ def decompress_nsz_file(
             if file_size == 0:
                 raise ValueError(f"NSZ file is empty: {nsz_file_path}")
 
-            log_error(f"Attempting NSZ decompression of {filename} ({file_size} bytes)")
+            log_nsz(f"Attempting NSZ decompression of {filename} ({file_size} bytes)")
 
             # Pre-flight capacity check: decompressed NSP roughly doubles the
             # NSZ size. Block before extraction when the target can't hold it
@@ -154,7 +160,7 @@ def decompress_nsz_file(
             est_output = file_size * 2
             ok, reason = check_output_capacity(output_dir, est_output)
             if not ok:
-                log_error(f"Capacity check failed for {filename}: {reason}")
+                log_nsz(f"Capacity check failed for {filename}: {reason}")
                 update_progress(reason, 0)
                 return False
 
@@ -182,24 +188,30 @@ def decompress_nsz_file(
                 progress_callback=_on_progress,
             )
             nsz_success = True
-            log_error("NSZ decompression successful using nsz library")
+            log_nsz("NSZ decompression successful using nsz library")
 
         except Exception as e:
+            import traceback
+
             error_msg = f"NSZ library decompression failed: {e}"
             print(error_msg)
-            log_error(f"NSZ library method failed for {filename}: {str(e)}")
-            log_error(f"NSZ file path: {nsz_file_path}")
-            log_error(f"Output directory: {output_dir}")
-            log_error(f"Keys path: {keys_path}")
+            log_nsz(
+                f"NSZ library method failed for {filename}: {e}",
+                traceback_str=traceback.format_exc(),
+            )
+            log_nsz(f"NSZ file path: {nsz_file_path}")
+            log_nsz(f"Output directory: {output_dir}")
+            log_nsz(f"Keys path: {keys_path}")
 
             # Check if it's a corrupted file issue
             if "read returned empty" in str(e):
-                log_error("NSZ file appears to be corrupted or incomplete")
+                log_nsz("NSZ file appears to be corrupted or incomplete")
 
     if nsz_success:
+        log_nsz(f"NSZ completion: success file={filename}")
         update_progress(f"Decompressing {filename}... Complete", 100)
         return True
     else:
-        log_error(f"NSZ decompression failed for {filename}: All methods failed")
+        log_nsz(f"NSZ failure: file={filename} all methods failed")
         update_progress(f"NSZ decompression failed for {filename}", 0)
         return False

--- a/tests/test_nsz_logging.py
+++ b/tests/test_nsz_logging.py
@@ -1,0 +1,188 @@
+"""TDD (red) tests for GAB-58: NSZ debug logging to a dedicated nsz.log.
+
+NSZ decompression on Android fails silently. The fix adds a parallel,
+permission-hardened ``log_nsz`` logger writing to a dedicated ``nsz.log``
+(sibling of ``error.log`` in TEMP_LOG_DIR) and rewires the desktop NSZ
+decompression path to emit comprehensive diagnostics.
+
+Pinned NOT-YET-IMPLEMENTED behavior:
+    - utils.logging.log_nsz / utils.logging._nsz_log_file write to nsz.log,
+      NOT error.log.
+    - decompress_nsz_file routes ALL of its log calls through log_nsz, emits a
+      pre-call integer ``file_size=`` diagnostic, distinguishes the two silent
+      failure modes (``keys_path not set`` vs ``nsz library unavailable``), and
+      records a multi-line traceback (with the exception class name) on raise.
+    - log_nsz reuses the hardened _write_fallback path on a primary OSError.
+
+These access new symbols via the module objects so missing pieces surface as
+AttributeError ("not implemented yet"), not ImportError at collection time.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Keep nsz/ParseArguments out of pytest's argv when the nsz package imports.
+sys.argv = sys.argv[:1]
+
+# src (and src/nsz) on path so `utils` and the top-level `nsz` package resolve.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src", "nsz"))
+
+from utils import nsz as nsz_mod  # noqa: E402
+from utils import logging as L  # noqa: E402
+from utils.nsz import decompress_nsz_file  # noqa: E402
+
+
+def test_writes_to_dedicated_nsz_log_with_filename(tmp_path, monkeypatch):
+    """A successful decompress must write the basename to nsz.log."""
+    nsz_log = tmp_path / "nsz.log"
+    monkeypatch.setattr(L, "_nsz_log_file", str(nsz_log), raising=False)
+
+    monkeypatch.setattr(
+        nsz_mod, "check_output_capacity", lambda d, n: (True, None), raising=False
+    )
+    monkeypatch.setattr(
+        nsz_mod, "_nsz_decompress", lambda *a, **k: None, raising=False
+    )
+
+    nsz_file = tmp_path / "game.nsz"
+    nsz_file.write_bytes(b"\x00" * 1024)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    decompress_nsz_file(str(nsz_file), str(out_dir), "/fake/keys.txt")
+
+    assert nsz_log.exists(), "dedicated nsz.log was not created"
+    assert "game.nsz" in nsz_log.read_text()
+
+
+def test_multiline_traceback_on_raise(tmp_path, monkeypatch):
+    """An exception during decompression yields a multi-line entry with the
+    exception class name and a Traceback block."""
+    nsz_log = tmp_path / "nsz.log"
+    monkeypatch.setattr(L, "_nsz_log_file", str(nsz_log), raising=False)
+
+    monkeypatch.setattr(
+        nsz_mod, "check_output_capacity", lambda d, n: (True, None), raising=False
+    )
+
+    def boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(nsz_mod, "_nsz_decompress", boom, raising=False)
+
+    nsz_file = tmp_path / "game.nsz"
+    nsz_file.write_bytes(b"\x00" * 1024)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    decompress_nsz_file(str(nsz_file), str(out_dir), "/fake/keys.txt")
+
+    text = nsz_log.read_text()
+    assert "RuntimeError" in text
+    assert "boom" in text
+    assert "Traceback:" in text
+    assert "\n" in text
+
+
+def test_keys_path_not_set_distinct_token(tmp_path, monkeypatch):
+    """keys_path="" logs 'keys_path not set' and NOT 'nsz library unavailable'."""
+    nsz_log = tmp_path / "nsz.log"
+    monkeypatch.setattr(L, "_nsz_log_file", str(nsz_log), raising=False)
+
+    nsz_file = tmp_path / "game.nsz"
+    nsz_file.write_bytes(b"\x00" * 1024)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    result = decompress_nsz_file(str(nsz_file), str(out_dir), "")
+
+    assert result is False
+    text = nsz_log.read_text()
+    assert "keys_path not set" in text
+    assert "nsz library unavailable" not in text
+
+
+def test_library_unavailable_distinct_token(tmp_path, monkeypatch):
+    """When the nsz library genuinely cannot load (even after the re-import
+    branch), the path logs 'nsz library unavailable'."""
+    nsz_log = tmp_path / "nsz.log"
+    monkeypatch.setattr(L, "_nsz_log_file", str(nsz_log), raising=False)
+
+    monkeypatch.setattr(nsz_mod, "_nsz_decompress", None, raising=False)
+
+    # Block the re-import resurrection: the real nsz package IS importable in
+    # CI, so intercept __import__ for "nsz" to force the unavailable branch.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "nsz":
+            raise ImportError("nsz blocked for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    nsz_file = tmp_path / "game.nsz"
+    nsz_file.write_bytes(b"\x00" * 1024)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    # keys_path truthy so branch ordering reaches the library check.
+    result = decompress_nsz_file(str(nsz_file), str(out_dir), "/fake/keys.txt")
+
+    assert result is False
+    assert "nsz library unavailable" in nsz_log.read_text()
+
+
+def test_integer_file_size_logged_before_library_call(tmp_path, monkeypatch):
+    """An integer 'file_size=' diagnostic is logged before invoking the lib."""
+    nsz_log = tmp_path / "nsz.log"
+    monkeypatch.setattr(L, "_nsz_log_file", str(nsz_log), raising=False)
+
+    monkeypatch.setattr(
+        nsz_mod, "check_output_capacity", lambda d, n: (True, None), raising=False
+    )
+    monkeypatch.setattr(
+        nsz_mod, "_nsz_decompress", lambda *a, **k: None, raising=False
+    )
+
+    nsz_file = tmp_path / "game.nsz"
+    nsz_file.write_bytes(b"\x00" * 4096)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    decompress_nsz_file(str(nsz_file), str(out_dir), "/fake/keys.txt")
+
+    import re
+
+    text = nsz_log.read_text()
+    assert re.search(r"file_size=\d+", text), "no integer file_size= diagnostic logged"
+
+
+def test_fallback_on_primary_oserror(tmp_path, monkeypatch):
+    """A primary-write OSError routes the entry through _write_fallback."""
+    import builtins
+
+    real_open = builtins.open
+    primary = str(tmp_path / "primary" / "nsz.log")
+    monkeypatch.setattr(L, "_nsz_log_file", primary, raising=False)
+
+    def fake_open(path, *args, **kwargs):
+        if str(path) == primary:
+            raise OSError("read-only filesystem")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+    fallback_dir = tmp_path / "fallback"
+    fallback_dir.mkdir()
+    monkeypatch.setattr("tempfile.gettempdir", lambda: str(fallback_dir))
+
+    L.log_nsz("nsz-boom")
+
+    contents = [f.read_text() for f in fallback_dir.iterdir() if f.is_file()]
+    assert any("nsz-boom" in c for c in contents), "no fallback log written"


### PR DESCRIPTION
## Ticket

GAB-58 — [Android] NSZ decompression fails silently — add debug logging
https://linear.app/gabmoterani/issue/GAB-58/android-nsz-decompression-fails-silently-need-debug-logging-to

## Problem

NSZ decompression on Android was failing without producing useful diagnostics. The general error log did not indicate which step of the decompression pipeline was failing, making the issue impossible to triage from device logs.

## Root cause

There was no dedicated, stage-by-stage logging around the NSZ decompression path, and no separate log artifact for NSZ output. Failures (missing keys, unavailable NSZ library, runtime exceptions) were swallowed or only surfaced as opaque generic errors.

## Fix (files)

- `src/utils/logging.py`: Added `log_nsz`, a standalone copy of `log_error` that targets a dedicated `_nsz_log_file` (does not delegate to `log_error`, so nothing leaks into `error.log`). Keeps `print(flush=True)` for web-companion parity and reuses the hardened `_write_fallback` on `OSError`. Added `get_nsz_log_file()` accessor mirroring `get_log_file()`. `log_error` left untouched.
- `src/utils/nsz.py`: Switched to `from .logging import log_nsz`; removed all residual `log_error` calls. Added entry diagnostics (integer `file_size=` gated on existence), split the decompress guard into distinct greppable tokens (`keys_path not set` and `nsz library unavailable`, the latter correctly after the re-import attempt), added `traceback.format_exc()` to the except block, and explicit completion/failure lines. Capacity logic, filesystem detection, progress throttling, and the module import block are unchanged.
- `src/services/download_manager.py`: Bracketed the decompress call with a pre-call breadcrumb (file/path/size/keys_set) and a post-call result line. `log_error` import retained for the rest of the module. Move/zip/cleanup paths unchanged.
- `.gitignore`: Added `nsz.log` as a sibling to the existing `error.log` entry, so the runtime `src/nsz.log` artifact written in DEV_MODE is never committed.
- `tests/test_nsz_logging.py`: New test suite covering the logging branches.

## Testing

Ticket suite (`test_nsz_logging.py` + `test_nsz_capacity.py` + `test_logging_hardening.py`):
```
19 passed in 0.06s
```

Full suite (`.venv/bin/python -m pytest tests -q`):
```
275 passed, 3 warnings, no failures
```
The 3 warnings are pre-existing Pillow `getdata` deprecations in `test_flag_analyzer_mvp.py`, unrelated to this change.

## QA verdict

Initial QA: FAIL (one fix required) — implementation correct but left an untracked, non-gitignored `src/nsz.log` artifact at risk of being committed. Required fix was a one-line `.gitignore` addition (`nsz.log`), now applied. All other items PASS. This PR clears the FAIL.

Status: kept In Progress, awaiting human review/merge.
