### PR TITLE
fix(GAB-61): eliminate double sort and per-frame list copy in concatenated game lists

### DIFF
--- a/src/services/file_listing.py
+++ b/src/services/file_listing.py
@@ -313,19 +313,23 @@ def list_files(
                 ]
 
         # Deduplicate game list (prefer USA, then largest file)
+        already_sorted = False
         if settings.get("dedupe_game_list", False) and all_files:
             # Check for low-end device mode that skips expensive deduplication
             if settings.get("low_end_device_mode", False):
-                # Low-end mode: skip deduplication but do basic merge by sorting
+                # Low-end mode: skip deduplication but do basic merge by sorting.
+                # Mark as sorted so the unconditional pass below is skipped.
                 all_files.sort(key=lambda x: x.get("filename", "") if isinstance(x, dict) else str(x))
+                already_sorted = True
             else:
                 all_files = _dedupe_game_list(all_files)
 
-        # Sort combined list by filename
-        if all_files and isinstance(all_files[0], dict):
-            all_files.sort(key=lambda x: x.get("filename", ""))
-        else:
-            all_files.sort()
+        # Sort combined list by filename (skip when already sorted above)
+        if not already_sorted:
+            if all_files and isinstance(all_files[0], dict):
+                all_files.sort(key=lambda x: x.get("filename", ""))
+            else:
+                all_files.sort()
 
         return all_files
 

--- a/src/ui/screens/games_screen.py
+++ b/src/ui/screens/games_screen.py
@@ -87,10 +87,13 @@ class GamesScreen:
         # Reserve footer space for status bar when games are selected
         footer_height = 40 if selected_games else 0
 
-        # Add "Download All" as an extra item if enabled
-        display_items = list(games)
+        # Add "Download All" as an extra item if enabled.
+        # Avoid copying the entire list on every frame when the sentinel is not needed.
         if show_download_all and games:
+            display_items = list(games)
             display_items.append({"_download_all": True, "name": "Download All Games"})
+        else:
+            display_items = games
 
         # Adjust highlighted to not exceed display items
         display_highlighted = min(highlighted, len(display_items) - 1)

--- a/tests/test_gab_61_single_sort.py
+++ b/tests/test_gab_61_single_sort.py
@@ -1,0 +1,119 @@
+"""
+GAB-61 regression guard: low_end_device_mode must sort the concatenated
+multi-source game list EXACTLY ONCE.
+
+This closes the gap the architect spec flagged in test_list_files_perf.py:
+the existing TestNoDoubleSort falls back to correctness-only because the
+internal `all_files` accumulator is a plain list a network-mock TrackingList
+never becomes, and `list.sort` itself cannot be monkey-patched (immutable
+built-in type). Correctness (output == sorted(output)) cannot distinguish one
+sort from two -- a list sorted twice is still sorted.
+
+Vector that reaches the in-function accumulator without touching production
+code: the file items are dicts, and BOTH sort sites use the key
+`lambda x: x.get("filename", ...)`. CPython's list.sort computes the sort key
+exactly once per element per sort pass. So if we fill the accumulator with
+dicts that count `.get("filename")` calls, one sort over N items yields N key
+extractions and a redundant double sort yields 2N. We assert key extractions
+== N (single pass) in low_end_device_mode.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Must be set before any import to prevent NSZ arg-parser from consuming pytest argv
+sys.argv = [sys.argv[0]]
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+_src = os.path.join(os.path.dirname(__file__), "..", "src")
+sys.path.insert(0, _src)
+
+_fl_spec = importlib.util.spec_from_file_location(
+    "file_listing_gab61",
+    os.path.join(_src, "services", "file_listing.py"),
+)
+_fl_mod = importlib.util.module_from_spec(_fl_spec)
+_fl_spec.loader.exec_module(_fl_mod)
+list_files = _fl_mod.list_files
+
+
+# Shared counter for filename-key extractions across all items in a run.
+_KEY_READS = {"n": 0}
+
+
+class CountingDict(dict):
+    """A file dict that counts `.get('filename', ...)` accesses.
+
+    Both sort sites in list_files use key=lambda x: x.get("filename", ...).
+    CPython computes the sort key once per element per sort pass, so counting
+    these reads measures how many times the accumulator was sorted.
+    """
+
+    def get(self, key, default=None):
+        if key == "filename":
+            _KEY_READS["n"] += 1
+        return super().get(key, default)
+
+
+def _make_system_data():
+    return {"name": "TestSys", "url": ["http://example.com/roms/"]}
+
+
+def _make_settings(low_end=False, dedupe=False):
+    return {
+        "dedupe_game_list": dedupe,
+        "low_end_device_mode": low_end,
+        "filter_region": "none",
+    }
+
+
+class TestSingleSortInLowEndMode(unittest.TestCase):
+    N = 30
+
+    def _run(self, low_end, dedupe):
+        _KEY_READS["n"] = 0
+
+        def fake_html_single(system_data, settings, formats, url):
+            return [
+                CountingDict({"filename": f"Game {self.N - i:04d} (USA).zip", "size": i})
+                for i in range(self.N)
+            ]
+
+        with patch.object(
+            _fl_mod, "_list_files_html_single", side_effect=fake_html_single
+        ), patch.object(
+            _fl_mod, "_load_cached_listing", side_effect=lambda url: None
+        ), patch.object(
+            _fl_mod, "_save_listing_cache", side_effect=lambda url, data: None
+        ):
+            result = list_files(
+                _make_system_data(),
+                _make_settings(low_end=low_end, dedupe=dedupe),
+            )
+        return result, _KEY_READS["n"]
+
+    def test_low_end_mode_sorts_game_list_exactly_once(self):
+        result, key_reads = self._run(low_end=True, dedupe=True)
+
+        names = [f["filename"] for f in result]
+        self.assertEqual(names, sorted(names), "low_end output must be sorted")
+
+        # The only `.get("filename")` consumers in low_end mode are the sort
+        # key lambdas. One sort over N items reads the key N times; a redundant
+        # second sort reads 2*N. Assert single pass.
+        self.assertEqual(
+            key_reads,
+            self.N,
+            "low_end_device_mode must sort the concatenated game list exactly "
+            f"once. Expected {self.N} filename-key reads (single sort) but got "
+            f"{key_reads} (~{key_reads / self.N:.0f} sort passes); the "
+            "unconditional final sort must be skipped via the already_sorted flag",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_list_files_perf.py
+++ b/tests/test_list_files_perf.py
@@ -1,0 +1,331 @@
+"""
+Performance-correctness tests for list_files and GamesScreen (GAB-61).
+
+Covers:
+  - H1: double sort in low_end_device_mode branch
+  - H3: per-frame list(games) copy in GamesScreen.render when show_download_all=False
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Must be set before any import to prevent NSZ arg-parser from consuming pytest argv
+sys.argv = [sys.argv[0]]
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+_src = os.path.join(os.path.dirname(__file__), "..", "src")
+sys.path.insert(0, _src)
+
+_fl_spec = importlib.util.spec_from_file_location(
+    "file_listing",
+    os.path.join(_src, "services", "file_listing.py"),
+)
+_fl_mod = importlib.util.module_from_spec(_fl_spec)
+_fl_spec.loader.exec_module(_fl_mod)
+list_files = _fl_mod.list_files
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_files(n):
+    """Return n file dicts with filenames in reverse-sorted order."""
+    return [{"filename": f"Game {n - i:04d} (USA).zip", "size": i} for i in range(n)]
+
+
+def _make_system_data(urls=None):
+    return {"name": "TestSys", "url": urls or ["http://example.com/roms/"]}
+
+
+def _make_settings(low_end=False, dedupe=False):
+    return {
+        "dedupe_game_list": dedupe,
+        "low_end_device_mode": low_end,
+        "filter_region": "none",
+    }
+
+
+def _run_list_files(files, low_end=False, dedupe=False):
+    """Patch network to return `files` and call list_files."""
+
+    def fake_html_single(system_data, settings, formats, url):
+        return list(files)
+
+    def fake_load_cache(url):
+        return None
+
+    def fake_save_cache(url, data):
+        pass
+
+    with patch.object(_fl_mod, "_list_files_html_single", side_effect=fake_html_single), \
+         patch.object(_fl_mod, "_load_cached_listing", side_effect=fake_load_cache), \
+         patch.object(_fl_mod, "_save_listing_cache", side_effect=fake_save_cache):
+        return list_files(
+            _make_system_data(),
+            _make_settings(low_end=low_end, dedupe=dedupe),
+        )
+
+
+# ---------------------------------------------------------------------------
+# H1 — double sort in low_end_device_mode
+# ---------------------------------------------------------------------------
+
+class TestSortCorrectness(unittest.TestCase):
+    """list_files result is always sorted regardless of mode."""
+
+    def test_result_is_sorted_default(self):
+        result = _run_list_files(_make_files(20))
+        names = [f["filename"] for f in result]
+        self.assertEqual(names, sorted(names))
+
+    def test_result_is_sorted_low_end_mode(self):
+        result = _run_list_files(_make_files(20), low_end=True, dedupe=True)
+        names = [f["filename"] for f in result]
+        self.assertEqual(names, sorted(names))
+
+    def test_result_is_sorted_dedupe_mode(self):
+        result = _run_list_files(_make_files(20), dedupe=True)
+        names = [f["filename"] for f in result]
+        self.assertEqual(names, sorted(names))
+
+
+class TestNoDoubleSort(unittest.TestCase):
+    """low_end_device_mode must not sort the same list twice."""
+
+    def test_low_end_mode_sorts_only_once(self):
+        """
+        Instrument list_files to count how many times the all_files list is
+        sorted inside the function.  We do this by wrapping the module-level
+        `list` builtin *via the module namespace* and tracking the sort path.
+
+        Strategy: replace `_fl_mod._dedupe_game_list` temporarily so we can
+        observe how the low_end branch uses the returned list, and then check
+        that the final unconditional sort (lines 325-328) does not re-sort a
+        list that was already sorted by the low_end branch.
+
+        Simpler proxy: assert the output is sorted AND call list_files twice
+        with the SAME reverse-ordered data; if there were a double sort the
+        intermediate state would still be correct, but we can detect the
+        problem differently by injecting a sort sentinel.
+        """
+        # Build a reverse-sorted list so that after ONE correct sort the
+        # result is ascending.  If sorted twice the result is still ascending
+        # so correctness alone does not prove single-pass.  We instead verify
+        # by checking the implementation path: when low_end_device_mode=True
+        # the early sort (line 320) puts the list in order; the later
+        # unconditional sort (lines 325-328) is redundant.
+        #
+        # We track this by patching the module's `sorted` builtin reference
+        # and counting calls.  The low_end branch uses list.sort (in-place),
+        # not sorted(), but the final unconditional block also uses list.sort.
+        # We wrap _fl_mod's list-sorting by monkey-patching the all_files
+        # accumulator through _dedupe_game_list.
+
+        # Cleaner approach: count via a custom key function.
+        call_counter = {"n": 0}
+        original_sort = list.sort
+
+        # Patch via wrapping list_files at the source level is difficult
+        # without instrumenting the function body.  Instead verify the property
+        # by asserting the implementation does not regress: low_end path must
+        # produce sorted output (already tested above), AND we confirm there is
+        # exactly one sort by checking that a spy key function is called the
+        # expected number of times.
+
+        # We inject a side-effecting key into _fl_mod's sort by temporarily
+        # replacing the lambda used in the low_end branch.  Since we cannot
+        # easily intercept inline lambdas, we use a different approach:
+        # run the function with a pre-sorted list and verify the count of
+        # sort operations via an instrumented list subclass injected through
+        # the _list_files_html_single mock.
+
+        sort_calls = []
+
+        class TrackingList(list):
+            def sort(self, **kwargs):
+                sort_calls.append("sort")
+                return super().sort(**kwargs)
+
+        def fake_html_single(system_data, settings, formats, url):
+            tl = TrackingList(_make_files(30))
+            return tl
+
+        def fake_load_cache(url):
+            return None
+
+        def fake_save_cache(url, data):
+            pass
+
+        with patch.object(_fl_mod, "_list_files_html_single", side_effect=fake_html_single), \
+             patch.object(_fl_mod, "_load_cached_listing", side_effect=fake_load_cache), \
+             patch.object(_fl_mod, "_save_listing_cache", side_effect=fake_save_cache):
+            result = list_files(
+                _make_system_data(),
+                _make_settings(low_end=True, dedupe=True),
+            )
+
+        # The result list is a plain list (not TrackingList) because list_files
+        # uses all_files.extend() then sorts all_files which is a plain list.
+        # The TrackingList items are extended into all_files (a plain list),
+        # so the inner sort calls are on all_files.  Both the low_end sort and
+        # the final sort operate on all_files.  We cannot instrument all_files
+        # from outside without modifying the function.
+        #
+        # Fallback: verify correctness only and document that the
+        # implementation-level double-sort is caught by the code fix.
+        names = [f["filename"] for f in result]
+        self.assertEqual(names, sorted(names), "Output must be sorted in low_end mode")
+
+    def test_low_end_double_sort_is_redundant(self):
+        """
+        Regression: verifies the two sort paths in low_end_device_mode do not
+        produce conflicting behaviour by asserting a multi-source list is
+        correctly sorted exactly once with no duplicates.
+        """
+        # Two sources, each with reverse-sorted 10-item lists
+        files_a = [{"filename": f"Alpha Game {10 - i:02d} (USA).zip", "size": i} for i in range(10)]
+        files_b = [{"filename": f"Beta Game {10 - i:02d} (USA).zip", "size": i} for i in range(10)]
+        all_input = files_a + files_b
+
+        def fake_html_single(system_data, settings, formats, url):
+            return list(all_input)
+
+        def fake_load_cache(url):
+            return None
+
+        def fake_save_cache(url, data):
+            pass
+
+        with patch.object(_fl_mod, "_list_files_html_single", side_effect=fake_html_single), \
+             patch.object(_fl_mod, "_load_cached_listing", side_effect=fake_load_cache), \
+             patch.object(_fl_mod, "_save_listing_cache", side_effect=fake_save_cache):
+            result = list_files(
+                _make_system_data(),
+                _make_settings(low_end=True, dedupe=True),
+            )
+
+        names = [f["filename"] for f in result]
+        self.assertEqual(names, sorted(names))
+        # No duplicates
+        self.assertEqual(len(names), len(set(names)))
+
+
+# ---------------------------------------------------------------------------
+# H3 — per-frame list(games) copy in GamesScreen.render
+# ---------------------------------------------------------------------------
+
+class TestGamesScreenNoCopyWhenNoDownloadAll(unittest.TestCase):
+    """
+    GamesScreen.render with show_download_all=False must NOT construct a full
+    shallow copy of the games list before passing to the template.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        import pygame
+        if not pygame.get_init():
+            pygame.init()
+
+    def _make_screen_mock(self):
+        screen = MagicMock()
+        screen.get_width.return_value = 800
+        screen.get_size.return_value = (800, 600)
+        screen.get_height.return_value = 600
+        return screen
+
+    def test_no_list_copy_when_show_download_all_false(self):
+        """items passed to list_template must be the original games object."""
+        from ui.screens.games_screen import GamesScreen
+
+        games = [{"filename": f"Game {i:04d} (USA).zip"} for i in range(100)]
+        gs = GamesScreen()
+        received = {}
+
+        def intercepting_render(surface, **kwargs):
+            received["items"] = kwargs.get("items")
+            return None, [], 0
+
+        gs.list_template.render = intercepting_render
+
+        gs.render(
+            screen=self._make_screen_mock(),
+            system_name="TestSys",
+            games=games,
+            highlighted=0,
+            selected_games=set(),
+            show_download_all=False,
+        )
+
+        self.assertIn("items", received, "list_template.render was not called")
+        self.assertIs(
+            received["items"],
+            games,
+            "render() must pass the original games list, not a copy, "
+            "when show_download_all=False",
+        )
+
+    def test_download_all_sentinel_appended_when_flag_true(self):
+        """When show_download_all=True, the sentinel item must be the last element."""
+        from ui.screens.games_screen import GamesScreen
+
+        games = [{"filename": "Game 0001 (USA).zip"}]
+        gs = GamesScreen()
+        received = {}
+
+        def intercepting_render(surface, **kwargs):
+            received["items"] = list(kwargs.get("items", []))
+            return None, [], 0
+
+        gs.list_template.render = intercepting_render
+
+        gs.render(
+            screen=self._make_screen_mock(),
+            system_name="TestSys",
+            games=games,
+            highlighted=0,
+            selected_games=set(),
+            show_download_all=True,
+        )
+
+        self.assertIn("items", received, "list_template.render was not called")
+        self.assertTrue(
+            any(isinstance(i, dict) and i.get("_download_all") for i in received["items"]),
+            "Sentinel 'Download All' item must be present when show_download_all=True",
+        )
+
+    def test_empty_games_no_download_all_sentinel(self):
+        """When games is empty and show_download_all=True, sentinel must NOT appear."""
+        from ui.screens.games_screen import GamesScreen
+
+        games = []
+        gs = GamesScreen()
+        received = {}
+
+        def intercepting_render(surface, **kwargs):
+            received["items"] = list(kwargs.get("items", []))
+            return None, [], 0
+
+        gs.list_template.render = intercepting_render
+
+        gs.render(
+            screen=self._make_screen_mock(),
+            system_name="TestSys",
+            games=games,
+            highlighted=0,
+            selected_games=set(),
+            show_download_all=True,
+        )
+
+        self.assertFalse(
+            any(isinstance(i, dict) and i.get("_download_all") for i in received.get("items", [])),
+            "Sentinel must not appear when games list is empty",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Ticket
GAB-61 — Game system backups navigation is slow when multiple systems are concatenated in Woodpull lists
https://linear.app/gabmoterani/issue/GAB-61/game-system-backups-navigation-is-slow-when-multiple-systems-are

## Problem
Navigating Game backups was significantly slower when a list concatenated multiple systems (Woodpull lists). Single-system lists navigated fine. The slowdown was most noticeable on Android during normal browsing.

## Root cause
1. Concatenated multi-source lists were sorted twice: the low-end branch sorted by filename, and an unconditional final sort ran again over the same (large) list.
2. The games screen allocated a fresh `list(games)` copy on every frame, adding per-frame allocation pressure proportional to list size.

## Fix (files)
- `src/services/file_listing.py` (lines ~316-332): added an `already_sorted` flag. The low-end branch sorts once with `key=lambda x: x.get("filename","") if isinstance(x, dict) else str(x)` and sets `already_sorted=True`; the unconditional final sort is skipped only in that case. Default and dedupe (non-low-end) paths still perform exactly one sort.
- `src/ui/screens/games_screen.py` (lines ~90-96): guarded the `list(games)` copy. The common path now aliases `games` directly (zero allocation); downstream consumers only read items, so aliasing is safe. `download_all_rect` is keyed off `len(games)` and remains valid.

## Testing
- Full suite: `278 passed, 3 warnings in 3.85s` (the 3 warnings are pre-existing Pillow `getdata` DeprecationWarnings in `test_flag_analyzer_mvp.py`, unrelated to this change).
- Ticket regression + perf files: `tests/test_gab_61_single_sort.py` + `tests/test_list_files_perf.py` = `9 passed`.
- The regression test counts `.get("filename")` calls via a `CountingDict` and asserts exactly N=30 reads (a single sort); reverting `already_sorted=True` makes it fail with `60 != 30`, confirming it catches the double sort for the right reason.

## QA verdict
PASS. The `already_sorted` flag is correct and minimal; the `list(games)` copy guard introduces no mutation hazard (verified no downstream consumer mutates the items list). Adversarial check: reverting the flag failed the ticket test as expected, then restored byte-identical.