### PR TITLE
feat(GAB-58): in-app NSZ log viewer with save-to-error.log

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1165,6 +1165,10 @@ class ConsoleUtilitiesApp:
                     self.state.ui_rects.confirm_cancel_button = rects.get(
                         "confirm_cancel"
                     )
+                    self.state.ui_rects.nsz_log_save_button = rects.get("nsz_log_save")
+                    self.state.ui_rects.nsz_log_close_button = rects.get(
+                        "nsz_log_close"
+                    )
                     self.state.ui_rects.rects = rects
 
                     if self.scanline_surface:
@@ -1302,6 +1306,21 @@ class ConsoleUtilitiesApp:
                 self.state.confirm_modal.button_index = (
                     1 - self.state.confirm_modal.button_index
                 )
+            return
+
+        if self.state.nsz_log_modal.show:
+            modal = self.state.nsz_log_modal
+            if direction in ("left", "right"):
+                modal.button_index = 1 - modal.button_index
+            elif direction in ("up", "down"):
+                max_offset = self.screen_manager.nsz_log_modal.max_scroll_offset(
+                    modal.lines
+                )
+                step = 1
+                if direction == "down":
+                    modal.scroll_offset = min(modal.scroll_offset + step, max_offset)
+                else:
+                    modal.scroll_offset = max(modal.scroll_offset - step, 0)
             return
 
         # Internet Archive modals navigation
@@ -2856,6 +2875,18 @@ class ConsoleUtilitiesApp:
                     return
             return
 
+        # Check NSZ log modal buttons
+        if self.state.nsz_log_modal.show:
+            if self.state.ui_rects.nsz_log_save_button:
+                if self.state.ui_rects.nsz_log_save_button.collidepoint(x, y):
+                    self._save_nsz_log_to_error_log()
+                    return
+            if self.state.ui_rects.nsz_log_close_button:
+                if self.state.ui_rects.nsz_log_close_button.collidepoint(x, y):
+                    self.state.nsz_log_modal.show = False
+                    return
+            return
+
         # Check steam shortcut modal clicks
         if (
             self.state.steam_shortcut.show
@@ -3339,6 +3370,8 @@ class ConsoleUtilitiesApp:
                 self.state.auth_token_input.show = False
         elif self.state.confirm_modal.show:
             self._handle_confirm_modal_cancel()
+        elif self.state.nsz_log_modal.show:
+            self.state.nsz_log_modal.show = False
         elif self.state.url_input.show:
             self.state.url_input.show = False
         elif self.state.folder_name_input.show:
@@ -3556,6 +3589,10 @@ class ConsoleUtilitiesApp:
                 self._handle_confirm_modal_ok()
             else:
                 self._handle_confirm_modal_cancel()
+            return
+
+        if self.state.nsz_log_modal.show:
+            self._handle_nsz_log_modal_select()
             return
 
         if self.state.auth_token_input.show:
@@ -3858,6 +3895,34 @@ class ConsoleUtilitiesApp:
                 self.download_manager.remove_from_queue(queue.highlighted)
             elif item.status in ("downloading", "extracting", "moving"):
                 self.download_manager.cancel_current()
+
+    def _open_nsz_log_modal(self):
+        """Open the NSZ decompression log viewer.
+
+        Populates the modal from the in-memory NSZ buffer (with an nsz.log file
+        fallback) so the diagnostics are visible in-app even when the log file
+        is unreachable on the device.
+        """
+        from utils.logging import read_nsz_log_lines
+
+        self.state.nsz_log_modal.lines = read_nsz_log_lines()
+        self.state.nsz_log_modal.scroll_offset = 0
+        self.state.nsz_log_modal.button_index = 0
+        self.state.nsz_log_modal.saved = False
+        self.state.nsz_log_modal.show = True
+
+    def _handle_nsz_log_modal_select(self):
+        """Activate the focused NSZ log modal button (Save or Close)."""
+        if self.state.nsz_log_modal.button_index == 0:
+            self._save_nsz_log_to_error_log()
+        else:
+            self.state.nsz_log_modal.show = False
+
+    def _save_nsz_log_to_error_log(self):
+        """Force-save the NSZ diagnostics into the retrievable error.log."""
+        from utils.logging import save_nsz_log_to_error_log
+
+        self.state.nsz_log_modal.saved = save_nsz_log_to_error_log()
 
     def _show_download_all_confirm(self):
         """Show confirmation modal for downloading all games."""
@@ -6461,6 +6526,13 @@ class ConsoleUtilitiesApp:
         elif self.state.mode == "file_explorer":
             self._open_file_explorer_context_menu()
 
+        elif self.state.mode == "downloads":
+            # See the NSZ decompression log for a failed download.
+            queue = self.state.download_queue
+            if queue.items and 0 <= queue.highlighted < len(queue.items):
+                if queue.items[queue.highlighted].status == "failed":
+                    self._open_nsz_log_modal()
+
     def _handle_start_action(self):
         """Handle start key press - download selected games or go home."""
         # If in games mode with selected games, start download
@@ -6690,6 +6762,7 @@ class ConsoleUtilitiesApp:
         return (
             self.state.show_search_input
             or self.state.game_details.show
+            or self.state.nsz_log_modal.show
             or self.state.folder_browser.show
             or self.state.url_input.show
             or self.state.folder_name_input.show

--- a/src/state.py
+++ b/src/state.py
@@ -180,6 +180,17 @@ class ConfirmModalState:
 
 
 @dataclass
+class NszLogModalState:
+    """State for the NSZ decompression log viewer modal."""
+
+    show: bool = False
+    lines: List[str] = field(default_factory=list)
+    scroll_offset: int = 0
+    button_index: int = 0  # 0 = Save to error.log, 1 = Close
+    saved: bool = False  # True once the log has been saved to error.log
+
+
+@dataclass
 class IALoginState:
     """State for Internet Archive login modal."""
 
@@ -1037,6 +1048,8 @@ class UIRects:
     folder_cancel_button: Optional[pygame.Rect] = None
     confirm_ok_button: Optional[pygame.Rect] = None
     confirm_cancel_button: Optional[pygame.Rect] = None
+    nsz_log_save_button: Optional[pygame.Rect] = None
+    nsz_log_close_button: Optional[pygame.Rect] = None
     modal_char_rects: List[Any] = field(default_factory=list)
     modal_back_button: Optional[pygame.Rect] = None
     scroll_offset: int = 0  # Current scroll offset for item index calculation
@@ -1102,6 +1115,7 @@ class AppState:
         self.game_details = GameDetailsState()
         self.loading = LoadingState()
         self.confirm_modal = ConfirmModalState()
+        self.nsz_log_modal = NszLogModalState()
         self.show_search_input: bool = False
         self.show_controller_mapping: bool = False
 
@@ -1252,6 +1266,7 @@ class AppState:
         self.folder_name_input.show = False
         self.url_input.show = False
         self.game_details.show = False
+        self.nsz_log_modal.show = False
         self.show_search_input = False
         self.char_selector.active = False
         self.ia_login.show = False

--- a/src/ui/screens/downloads_screen.py
+++ b/src/ui/screens/downloads_screen.py
@@ -426,6 +426,8 @@ class DownloadsScreen:
             item = queue.items[queue.highlighted]
             if item.status in ("waiting", "failed", "cancelled"):
                 hints.append(get_button_hint("select", "Remove", input_mode))
+                if item.status == "failed":
+                    hints.append(get_button_hint("detail", "See logs", input_mode))
             elif item.status in ("downloading", "extracting", "moving"):
                 hints.append(get_button_hint("select", "Cancel", input_mode))
 

--- a/src/ui/screens/modals/nsz_log_modal.py
+++ b/src/ui/screens/modals/nsz_log_modal.py
@@ -1,0 +1,131 @@
+"""
+NSZ log viewer modal.
+
+Shows captured NSZ decompression diagnostics in a scrollable view with a
+"Save to error.log" action. Used after an NSZ extraction fails so the logs are
+visible in-app even when the nsz.log file is unreachable (e.g. Android).
+"""
+
+import pygame
+from typing import List, Tuple
+
+from ui.theme import Theme, default_theme
+from ui.templates.modal_template import ModalTemplate
+from ui.atoms.text import Text
+
+
+class NszLogModal:
+    """Scrollable NSZ log viewer with Save/Close actions."""
+
+    WIDTH = 660
+    HEIGHT = 360
+    LINE_HEIGHT = 18
+
+    def __init__(self, theme: Theme = default_theme):
+        self.theme = theme
+        self.modal_template = ModalTemplate(theme)
+        self.text = Text(theme)
+
+    def _visible_lines(self) -> int:
+        """Number of log lines that fit in the content area."""
+        # HEIGHT minus a little headroom for the title gap, divided by line height.
+        usable = self.HEIGHT - self.theme.padding_md * 2
+        return max(1, usable // self.LINE_HEIGHT)
+
+    def max_scroll_offset(self, lines: List[str]) -> int:
+        """Largest valid top-line index so the last line stays visible."""
+        return max(0, len(lines) - self._visible_lines())
+
+    def render(
+        self,
+        screen: pygame.Surface,
+        lines: List[str],
+        scroll_offset: int = 0,
+        button_index: int = 0,
+    ) -> Tuple[pygame.Rect, pygame.Rect, pygame.Rect]:
+        """
+        Render the NSZ log modal.
+
+        Args:
+            screen: Surface to render to
+            lines: Log lines to display (oldest first)
+            scroll_offset: Index of the first visible line
+            button_index: Focused button (0 = Save, 1 = Close)
+
+        Returns:
+            Tuple of (modal_rect, save_button_rect, close_button_rect)
+        """
+        # Focused button gets the primary style; the other stays secondary.
+        save_style = "primary" if button_index == 0 else "secondary"
+        close_style = "primary" if button_index == 1 else "secondary"
+        buttons = [
+            ("Save to error.log", save_style),
+            ("Close", close_style),
+        ]
+
+        modal_rect, content_rect, _close_rect, button_rects = (
+            self.modal_template.render(
+                screen,
+                self.WIDTH,
+                self.HEIGHT,
+                title="NSZ Decompression Log",
+                show_close=False,
+                buttons=buttons,
+            )
+        )
+
+        visible = self._visible_lines()
+        max_offset = self.max_scroll_offset(lines)
+        offset = max(0, min(scroll_offset, max_offset))
+
+        if not lines:
+            self.text.render(
+                screen,
+                "No NSZ log entries captured yet.",
+                (content_rect.left, content_rect.top),
+                color=self.theme.text_secondary,
+                size=self.theme.font_size_sm,
+                max_width=content_rect.width,
+            )
+        else:
+            prev_clip = screen.get_clip()
+            screen.set_clip(content_rect)
+            y = content_rect.top
+            for line in lines[offset:offset + visible]:
+                self.text.render(
+                    screen,
+                    line if line else " ",
+                    (content_rect.left, y),
+                    color=self.theme.text_primary,
+                    size=self.theme.font_size_xs,
+                    max_width=content_rect.width,
+                )
+                y += self.LINE_HEIGHT
+            screen.set_clip(prev_clip)
+
+            # Scroll indicators.
+            if offset > 0:
+                self._scroll_arrow(screen, content_rect, "up")
+            if offset < max_offset:
+                self._scroll_arrow(screen, content_rect, "down")
+
+        save_rect, close_button_rect = button_rects[0], button_rects[1]
+        return modal_rect, save_rect, close_button_rect
+
+    def _scroll_arrow(
+        self, screen: pygame.Surface, content_rect: pygame.Rect, direction: str
+    ):
+        size = 14
+        half = size // 2
+        x = content_rect.right - size
+        if direction == "up":
+            y = content_rect.top
+            points = [(x, y), (x - half, y + half), (x + half, y + half)]
+        else:
+            y = content_rect.bottom - half
+            points = [(x - half, y - half), (x + half, y - half), (x, y)]
+        pygame.draw.polygon(screen, self.theme.text_secondary, points)
+
+
+# Default instance
+nsz_log_modal = NszLogModal()

--- a/src/ui/screens/screen_manager.py
+++ b/src/ui/screens/screen_manager.py
@@ -20,6 +20,7 @@ from .modals.folder_browser_modal import FolderBrowserModal
 from .modals.game_details_modal import GameDetailsModal
 from .modals.loading_modal import LoadingModal
 from .modals.error_modal import ErrorModal
+from .modals.nsz_log_modal import NszLogModal
 from .modals.url_input_modal import UrlInputModal
 from .modals.folder_name_modal import FolderNameModal
 from .modals.confirm_modal import ConfirmModal
@@ -101,6 +102,7 @@ class ScreenManager:
         self.game_details_modal = GameDetailsModal(theme)
         self.loading_modal = LoadingModal(theme)
         self.error_modal = ErrorModal(theme)
+        self.nsz_log_modal = NszLogModal(theme)
         self.url_input_modal = UrlInputModal(theme)
         self.folder_name_modal = FolderNameModal(theme)
         self.confirm_modal = ConfirmModal(theme)
@@ -174,6 +176,18 @@ class ScreenManager:
             rects["confirm_ok"] = ok_rect
             rects["confirm_cancel"] = cancel_rect
             rects["close"] = close_rect
+            return rects
+
+        if state.nsz_log_modal.show:
+            modal_rect, save_rect, close_rect = self.nsz_log_modal.render(
+                screen,
+                state.nsz_log_modal.lines,
+                state.nsz_log_modal.scroll_offset,
+                state.nsz_log_modal.button_index,
+            )
+            rects["modal"] = modal_rect
+            rects["nsz_log_save"] = save_rect
+            rects["nsz_log_close"] = close_rect
             return rects
 
         if state.auth_token_input.show:

--- a/src/utils/logging.py
+++ b/src/utils/logging.py
@@ -6,14 +6,21 @@ Provides logging with timestamps, file output, and stdout mirroring.
 import os
 import sys
 import tempfile
+from collections import deque
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 from constants import TEMP_LOG_DIR
 
 # Module-level log file path
 _log_file: str = os.path.join(TEMP_LOG_DIR, "error.log")
 _nsz_log_file: str = os.path.join(TEMP_LOG_DIR, "nsz.log")
+
+# In-memory NSZ diagnostics buffer. The nsz.log file is often unreachable on
+# Android (sandboxed app storage), so every log_nsz() entry is also captured
+# here for the in-app log viewer. Capped so a long session can't grow unbounded.
+NSZ_LOG_BUFFER_MAX: int = 1000
+_nsz_log_buffer: "deque[str]" = deque(maxlen=NSZ_LOG_BUFFER_MAX)
 
 
 def get_log_file() -> str:
@@ -111,6 +118,13 @@ def log_nsz(
     # Always print to stdout (captured by web companion's _LogCapture)
     print(log_message, flush=True)
 
+    # Capture to the in-memory buffer for the in-app viewer (display-friendly,
+    # no separator rule). Survives even when the file write below fails.
+    entry = log_message
+    if traceback_str:
+        entry += f"\nTraceback:\n{traceback_str}"
+    _nsz_log_buffer.append(entry)
+
     # Build full file entry with traceback
     file_message = log_message + "\n"
     if traceback_str:
@@ -123,6 +137,70 @@ def log_nsz(
     except OSError as e:
         print(f"Failed to write log to {_nsz_log_file}: {e}", file=sys.stderr, flush=True)
         _write_fallback(file_message)
+
+
+def get_nsz_log_buffer() -> List[str]:
+    """Return a copy of the in-memory NSZ log entries (oldest first)."""
+    return list(_nsz_log_buffer)
+
+
+def clear_nsz_log_buffer() -> None:
+    """Drop all captured in-memory NSZ log entries."""
+    _nsz_log_buffer.clear()
+
+
+def read_nsz_log_lines() -> List[str]:
+    """Return NSZ diagnostics as display lines for the in-app viewer.
+
+    Prefers the in-memory buffer (always available, even on Android where the
+    file path is unreachable). Falls back to reading ``nsz.log`` from disk when
+    the buffer is empty. Returns an empty list when neither source has content.
+    """
+    if _nsz_log_buffer:
+        lines: List[str] = []
+        for entry in _nsz_log_buffer:
+            lines.extend(entry.splitlines())
+        return lines
+
+    try:
+        with open(_nsz_log_file, "r") as f:
+            return f.read().splitlines()
+    except OSError:
+        return []
+
+
+def save_nsz_log_to_error_log() -> bool:
+    """Append the current NSZ diagnostics into the main ``error.log``.
+
+    The error log is the one location users can reliably retrieve, so this lets
+    them force the NSZ diagnostics there for sharing. Returns True when content
+    was written, False when there was nothing to save or the write failed.
+    """
+    lines = read_nsz_log_lines()
+    if not lines:
+        return False
+
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    block = (
+        f"\n===== NSZ LOG (saved {timestamp}) =====\n"
+        + "\n".join(lines)
+        + "\n"
+        + "=" * 80
+        + "\n"
+    )
+    try:
+        with open(_log_file, "a") as f:
+            f.write(block)
+        print(f"NSZ log saved to {_log_file}", flush=True)
+        return True
+    except OSError as e:
+        print(
+            f"Failed to save NSZ log to {_log_file}: {e}",
+            file=sys.stderr,
+            flush=True,
+        )
+        _write_fallback(block)
+        return False
 
 
 def init_log_file() -> bool:

--- a/tests/test_nsz_log_modal.py
+++ b/tests/test_nsz_log_modal.py
@@ -1,0 +1,79 @@
+"""Render-contract tests for the NSZ log viewer modal (GAB-58 follow-up)."""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+sys.argv = sys.argv[:1]
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+import pygame  # noqa: E402
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+sys.path.insert(0, _SRC)
+
+
+def _load_module(name, relpath):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_SRC, relpath)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_modal_mod = _load_module("nsz_log_modal", "ui/screens/modals/nsz_log_modal.py")
+NszLogModal = _modal_mod.NszLogModal
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _pygame_ctx():
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+@pytest.fixture
+def screen():
+    return pygame.Surface((800, 600))
+
+
+def test_render_returns_modal_save_and_close_rects(screen):
+    modal = NszLogModal()
+    modal_rect, save_rect, close_rect = modal.render(
+        screen, ["line one", "line two"], scroll_offset=0, button_index=0
+    )
+    assert isinstance(modal_rect, pygame.Rect)
+    assert isinstance(save_rect, pygame.Rect)
+    assert isinstance(close_rect, pygame.Rect)
+    assert save_rect != close_rect
+
+
+def test_render_handles_many_lines_and_scroll(screen):
+    modal = NszLogModal()
+    lines = [f"log line {i}" for i in range(500)]
+    # Deep scroll and out-of-range scroll must not raise.
+    modal.render(screen, lines, scroll_offset=480, button_index=1)
+    modal.render(screen, lines, scroll_offset=99999, button_index=0)
+
+
+def test_render_handles_empty_lines(screen):
+    modal = NszLogModal()
+    modal_rect, save_rect, close_rect = modal.render(
+        screen, [], scroll_offset=0, button_index=1
+    )
+    assert isinstance(modal_rect, pygame.Rect)
+
+
+def test_max_scroll_offset_is_non_negative_and_bounded(screen):
+    modal = NszLogModal()
+    # Few lines: nothing to scroll.
+    assert modal.max_scroll_offset(["a", "b"]) == 0
+    # Many lines: positive and less than total.
+    many = [f"l{i}" for i in range(500)]
+    ms = modal.max_scroll_offset(many)
+    assert 0 < ms < len(many)

--- a/tests/test_nsz_log_viewer.py
+++ b/tests/test_nsz_log_viewer.py
@@ -1,0 +1,106 @@
+"""Tests for the NSZ in-app log viewer data layer (GAB-58 follow-up).
+
+The dedicated nsz.log file is unreachable on Android, so log_nsz() must also
+capture entries to an in-memory ring buffer that an in-app modal can display,
+with a fallback to reading nsz.log from disk, plus a "force save to error.log"
+action so the diagnostics land in the one log the user can actually retrieve.
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+# Keep nsz/ParseArguments import-time argv parsing from choking on pytest args.
+sys.argv = sys.argv[:1]
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+sys.path.insert(0, _SRC)
+
+
+def _load_module(name, relpath):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_SRC, relpath)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Load utils/logging.py under a non-stdlib name so we never shadow `logging`.
+L = _load_module("cu_logging", "utils/logging.py")
+
+
+@pytest.fixture(autouse=True)
+def isolate_logs(tmp_path):
+    """Redirect both log files to tmp and start with an empty buffer."""
+    L._nsz_log_file = str(tmp_path / "nsz.log")
+    L._log_file = str(tmp_path / "error.log")
+    L.clear_nsz_log_buffer()
+    yield
+
+
+def test_log_nsz_captures_entry_to_buffer():
+    L.log_nsz("decompress started", error_type="INFO")
+    buf = L.get_nsz_log_buffer()
+    assert len(buf) == 1
+    assert "decompress started" in buf[0]
+    assert "INFO" in buf[0]
+
+
+def test_buffer_is_capped_dropping_oldest():
+    cap = L.NSZ_LOG_BUFFER_MAX
+    for i in range(cap + 25):
+        L.log_nsz(f"entry-{i}")
+    buf = L.get_nsz_log_buffer()
+    joined = "\n".join(buf)
+    assert len(buf) == cap
+    assert "entry-0" not in joined  # oldest dropped
+    assert f"entry-{cap + 24}" in joined  # newest kept
+
+
+def test_clear_buffer_empties_it():
+    L.log_nsz("something")
+    L.clear_nsz_log_buffer()
+    assert L.get_nsz_log_buffer() == []
+
+
+def test_read_lines_prefers_in_memory_buffer():
+    L.log_nsz("buffer-alpha")
+    lines = L.read_nsz_log_lines()
+    assert any("buffer-alpha" in line for line in lines)
+
+
+def test_read_lines_falls_back_to_file_when_buffer_empty(tmp_path):
+    L.clear_nsz_log_buffer()
+    with open(L._nsz_log_file, "w") as f:
+        f.write("file-line-1\nfile-line-2\n")
+    lines = L.read_nsz_log_lines()
+    assert "file-line-1" in lines
+    assert "file-line-2" in lines
+
+
+def test_read_lines_empty_when_no_buffer_and_no_file():
+    L.clear_nsz_log_buffer()
+    L._nsz_log_file = str(os.path.join(os.path.dirname(L._nsz_log_file), "missing.log"))
+    assert L.read_nsz_log_lines() == []
+
+
+def test_save_to_error_log_appends_buffer_content():
+    L.log_nsz("save-me-token")
+    ok = L.save_nsz_log_to_error_log()
+    assert ok is True
+    with open(L._log_file) as f:
+        content = f.read()
+    assert "save-me-token" in content
+    assert "NSZ LOG" in content  # a header marks the appended section
+
+
+def test_save_returns_false_when_nothing_to_save():
+    L.clear_nsz_log_buffer()
+    L._nsz_log_file = str(os.path.join(os.path.dirname(L._nsz_log_file), "missing.log"))
+    assert L.save_nsz_log_to_error_log() is False


### PR DESCRIPTION
Follow-up to GAB-58 (PR #39, merged). The dedicated `nsz.log` added there is unreachable on Android, so NSZ decompression failures still produced no visible diagnostics. This adds an in-app way to see and export them.

Linear: https://linear.app/gabmoterani/issue/GAB-58

## Problem
After a download tries to extract an `.nsz` and fails, the user had no way to see why on-device — the log file path is sandboxed/unreachable on Android.

## What this adds
- `log_nsz()` now also captures each entry to an in-memory ring buffer (capped at 1000), so diagnostics survive even when the file write target is unreachable.
- `read_nsz_log_lines()` returns the buffer, falling back to reading `nsz.log` from disk when the buffer is empty.
- `save_nsz_log_to_error_log()` force-appends the NSZ diagnostics into the retrievable `error.log`.
- New scrollable **NSZ log modal** (`nsz_log_modal.py`) with **Save to error.log** / **Close** actions.
- Opened from a **failed download** in the Downloads screen via the **detail button** (Y on gamepad / D on keyboard / long-press on touch), advertised by a new **"See logs"** footer hint. Wired into back/select/click handling and `_any_modal_open`.

## Testing
- New: `tests/test_nsz_log_viewer.py` (8) — buffer capture/cap/clear, file fallback, save-to-error.log.
- New: `tests/test_nsz_log_modal.py` (4) — render contract, scroll bounds, empty state.
- TDD: tests written first and verified failing (RED) before implementation (GREEN).
- Full suite: 316 passed (3 pre-existing Pillow deprecation warnings, unrelated).

## Notes
PR #39 was already merged, so this is a separate follow-up PR cut from current `main`. Android visual behavior (keyboard/modal) can't be exercised in CI; verification is via pytest + the logic/contract tests above.